### PR TITLE
Add basic continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ before_install:
   - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid warning
   - echo yes | sdkmanager "platforms;android-28"
 script:
-  - ./gradlew clean build
-
+  - ./gradlew clean assembleFullRelease
+  - ./gradlew clean assembleFdroidRelease

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ env:
   - ANDROID_BUILD_TOOLS=28.0.3
   - ADB_INSTALL_TIMEOUT=5
 before_install:
-- echo yes | sdkmanager "platforms;android-28"
+  - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid warning
+  - echo yes | sdkmanager "platforms;android-28"
 script:
   - ./gradlew clean build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: android
+script:
+  - ./gradlew build check

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,19 @@ android:
 env:
   global:
     - DIR=constraint-layout-start # Project directory
-    - API=28 # Android API level 25 by default
+    - API=28 # Android API level 28 by default
     - TAG=google_apis # Google APIs by default, alternatively use default
     - ABI=armeabi-v7a # ARM ABI v7a by default
     - QEMU_AUDIO_DRV=none # Disable emulator audio to avoid warning
     - GRADLE_USER_HOME="${TRAVIS_BUILD_DIR}/gradle" # Change location for Gradle Wrapper and cache
-    - ANDROID_HOME=/usr/local/android-sdk-28.0.2 # Depends on the cookbooks version used in the VM
+    - ANDROID_HOME=/usr/local/android-sdk-28.0.3 # Depends on the cookbooks version used in the VM
     - TOOLS=${ANDROID_HOME}/tools # PATH order matters, exists more than one emulator script
     - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 matrix:
   include: # More Emulator API levels to build in parallel
-    - env: API=24
+    - env: API=28
     - env: API=23
     - env: API=22
     - env: API=21

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,24 @@
 language: android
 jdk: oraclejdk8
-
 android:
-  components: # Cookbooks version: https://github.com/travis-ci/travis-cookbooks/tree/9c6cd11
-    - tools
-    - build-tools-28.0.3 # Match build-tools version used in build.gradle
-    - platform-tools # Update platform-tools to revision 25.0.3+
-    - tools # Update tools from revision 24.4.1 to 25.2.5
-
+  components:
+  - tools
+  - platform-tools
+  - tools
+  - build-tools-$ANDROID_BUILD_TOOLS
+  - android-$ANDROID_API
+  - extra-google-m2repository
+  - extra-android-m2repository
+  licenses:
+  - android-sdk-license-.+
+  - android-sdk-preview-license-.+
 env:
   global:
-    - API=28 # Android API level 28 by default
-    - ABI=armeabi-v7a # ARM ABI v7a by default
-
-install:
-  - sdkmanager --licenses
-
+  - ANDROID_API=28
+  - ANDROID_BUILD_TOOLS=28.0.3
+  - ADB_INSTALL_TIMEOUT=5
+before_install:
+- echo yes | sdkmanager "platforms;android-28"
 script:
   - ./gradlew clean build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,17 @@
 language: android
+jdk: oraclejdk8
+env:
+  global:
+    - ANDROID_TARGET=android-20
+    - ANDROID_ABI=armeabi-v7a
+android:
+  components:
+  - tools
+  - platform-tools
+  - build-tools-23.0.3
+  - android-23
+  - extra-android-m2repository
+  - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
 script:
   - ./gradlew build check
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,108 @@
 language: android
 jdk: oraclejdk8
+
+before_cache:
+  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/modules-2/modules-2.lock # Avoid to repack it due locks
+  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/3.3/classAnalysis/classAnalysis.lock
+  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/3.3/jarSnapshots/jarSnapshots.lock
+
+cache:
+  directories:
+    - ${TRAVIS_BUILD_DIR}/gradle/caches/
+    - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/
+
+notifications:
+  email: false
+
+android:
+  components: # Cookbooks version: https://github.com/travis-ci/travis-cookbooks/tree/9c6cd11
+    - tools
+    - build-tools-28.0.3 # Match build-tools version used in build.gradle
+    - platform-tools # Update platform-tools to revision 25.0.3+
+    - tools # Update tools from revision 24.4.1 to 25.2.5
+
 env:
   global:
-    - ANDROID_TARGET=android-20
-    - ANDROID_ABI=armeabi-v7a
-android:
-  components:
-  - tools
-  - platform-tools
-  - build-tools-23.0.3
-  - android-23
-  - extra-android-m2repository
-  - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
-script:
-  - ./gradlew build check
+    - DIR=constraint-layout-start # Project directory
+    - API=28 # Android API level 25 by default
+    - TAG=google_apis # Google APIs by default, alternatively use default
+    - ABI=armeabi-v7a # ARM ABI v7a by default
+    - QEMU_AUDIO_DRV=none # Disable emulator audio to avoid warning
+    - GRADLE_USER_HOME="${TRAVIS_BUILD_DIR}/gradle" # Change location for Gradle Wrapper and cache
+    - ANDROID_HOME=/usr/local/android-sdk-28.0.2 # Depends on the cookbooks version used in the VM
+    - TOOLS=${ANDROID_HOME}/tools # PATH order matters, exists more than one emulator script
+    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
+    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
+matrix:
+  include: # More Emulator API levels to build in parallel
+    - env: API=24
+    - env: API=23
+    - env: API=22
+    - env: API=21
+    - env: API=20
+    - env: API=19
+  allow_failures:
+    - env: API=23
+    - env: API=22
+    - env: API=21
+    - env: API=20
+    - env: API=19
+  fast_finish: false
+
+before_install:
+  - export EMULATOR="system-images;android-${API};${TAG};${ABI}" # Used to install/create emulator
+  - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid warning
+
+install:
+  # List and delete unnecessary components to free space
+  - sdkmanager --list || true
+  - sdkmanager --uninstall "system-images;android-15;default;armeabi-v7a"
+  - sdkmanager --uninstall "system-images;android-16;default;armeabi-v7a"
+  - sdkmanager --uninstall "system-images;android-17;default;armeabi-v7a"
+  - sdkmanager --uninstall "system-images;android-18;default;armeabi-v7a"
+  - sdkmanager --uninstall "extras;google;google_play_services"
+  - sdkmanager --uninstall "extras;android;support"
+  - sdkmanager --uninstall "platforms;android-10"
+  - sdkmanager --uninstall "platforms;android-15"
+  - sdkmanager --uninstall "platforms;android-16"
+  - sdkmanager --uninstall "platforms;android-17"
+  - sdkmanager --uninstall "platforms;android-18"
+  # Update sdk tools to latest version and install/update components
+  - echo yes | sdkmanager "tools"
+  - echo yes | sdkmanager "platforms;android-28" # Latest platform required by SDK tools
+  - echo yes | sdkmanager "platforms;android-${API}" # Android platform required by emulator
+  - echo yes | sdkmanager "extras;android;m2repository"
+  - echo yes | sdkmanager "extras;google;m2repository"
+  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
+  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
+  - echo yes | sdkmanager "$EMULATOR" # Install emulator system image
+  # Create and start emulator
+  - echo no | avdmanager create avd -n acib -k "$EMULATOR" -f --abi "$ABI" --tag "$TAG"
+  - emulator -avd acib -engine classic -no-window -camera-back none -camera-front none -verbose -qemu -m 512 &
+  # Start adbd, wait for device connected and show android serial
+  - adb wait-for-device get-serialno
+  # Show version and download Gradle Wrapper if it's not already cached
+  - cd ${TRAVIS_BUILD_DIR}/${DIR} && ./gradlew --version
+  # Clean project and download missing dependencies and components
+  - cd ${TRAVIS_BUILD_DIR}/${DIR} && ./gradlew clean build
+  # Check components status
+  - sdkmanager --list || true
+
+before_script:
+  # Wait for emulator fully-booted and disable animations
+  - android-wait-for-emulator
+  - adb shell settings put global window_animation_scale 0 &
+  - adb shell settings put global transition_animation_scale 0 &
+  - adb shell settings put global animator_duration_scale 0 &
+  - sleep 30
+  - adb shell input keyevent 82 &
+
+script:
+  # Run all device checks
+  - cd ${TRAVIS_BUILD_DIR}/${DIR} && ./gradlew connectedCheck
+
+after_script:
+  # Show tests and lint results
+  - cat ${TRAVIS_BUILD_DIR}/${DIR}/*/build/outputs/androidTest-results/connected/*
+  - cat ${TRAVIS_BUILD_DIR}/${DIR}/*/build/reports/lint-results.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,6 @@
 language: android
 jdk: oraclejdk8
 
-before_cache:
-  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/modules-2/modules-2.lock # Avoid to repack it due locks
-  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/3.3/classAnalysis/classAnalysis.lock
-  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/3.3/jarSnapshots/jarSnapshots.lock
-
-cache:
-  directories:
-    - ${TRAVIS_BUILD_DIR}/gradle/caches/
-    - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/
-
-notifications:
-  email: false
-
 android:
   components: # Cookbooks version: https://github.com/travis-ci/travis-cookbooks/tree/9c6cd11
     - tools
@@ -23,86 +10,12 @@ android:
 
 env:
   global:
-    - DIR=constraint-layout-start # Project directory
     - API=28 # Android API level 28 by default
-    - TAG=google_apis # Google APIs by default, alternatively use default
     - ABI=armeabi-v7a # ARM ABI v7a by default
-    - QEMU_AUDIO_DRV=none # Disable emulator audio to avoid warning
-    - GRADLE_USER_HOME="${TRAVIS_BUILD_DIR}/gradle" # Change location for Gradle Wrapper and cache
-    - ANDROID_HOME=/usr/local/android-sdk-28.0.3 # Depends on the cookbooks version used in the VM
-    - TOOLS=${ANDROID_HOME}/tools # PATH order matters, exists more than one emulator script
-    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
-    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
-
-matrix:
-  include: # More Emulator API levels to build in parallel
-    - env: API=28
-    - env: API=23
-    - env: API=22
-    - env: API=21
-    - env: API=20
-    - env: API=19
-  allow_failures:
-    - env: API=23
-    - env: API=22
-    - env: API=21
-    - env: API=20
-    - env: API=19
-  fast_finish: false
-
-before_install:
-  - export EMULATOR="system-images;android-${API};${TAG};${ABI}" # Used to install/create emulator
-  - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid warning
 
 install:
-  # List and delete unnecessary components to free space
-  - sdkmanager --list || true
-  - sdkmanager --uninstall "system-images;android-15;default;armeabi-v7a"
-  - sdkmanager --uninstall "system-images;android-16;default;armeabi-v7a"
-  - sdkmanager --uninstall "system-images;android-17;default;armeabi-v7a"
-  - sdkmanager --uninstall "system-images;android-18;default;armeabi-v7a"
-  - sdkmanager --uninstall "extras;google;google_play_services"
-  - sdkmanager --uninstall "extras;android;support"
-  - sdkmanager --uninstall "platforms;android-10"
-  - sdkmanager --uninstall "platforms;android-15"
-  - sdkmanager --uninstall "platforms;android-16"
-  - sdkmanager --uninstall "platforms;android-17"
-  - sdkmanager --uninstall "platforms;android-18"
-  # Update sdk tools to latest version and install/update components
-  - echo yes | sdkmanager "tools"
-  - echo yes | sdkmanager "platforms;android-28" # Latest platform required by SDK tools
-  - echo yes | sdkmanager "platforms;android-${API}" # Android platform required by emulator
-  - echo yes | sdkmanager "extras;android;m2repository"
-  - echo yes | sdkmanager "extras;google;m2repository"
-  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
-  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
-  - echo yes | sdkmanager "$EMULATOR" # Install emulator system image
-  # Create and start emulator
-  - echo no | avdmanager create avd -n acib -k "$EMULATOR" -f --abi "$ABI" --tag "$TAG"
-  - emulator -avd acib -engine classic -no-window -camera-back none -camera-front none -verbose -qemu -m 512 &
-  # Start adbd, wait for device connected and show android serial
-  - adb wait-for-device get-serialno
-  # Show version and download Gradle Wrapper if it's not already cached
-  - cd ${TRAVIS_BUILD_DIR}/${DIR} && ./gradlew --version
-  # Clean project and download missing dependencies and components
-  - cd ${TRAVIS_BUILD_DIR}/${DIR} && ./gradlew clean build
-  # Check components status
-  - sdkmanager --list || true
-
-before_script:
-  # Wait for emulator fully-booted and disable animations
-  - android-wait-for-emulator
-  - adb shell settings put global window_animation_scale 0 &
-  - adb shell settings put global transition_animation_scale 0 &
-  - adb shell settings put global animator_duration_scale 0 &
-  - sleep 30
-  - adb shell input keyevent 82 &
+  - sdkmanager --licenses
 
 script:
-  # Run all device checks
-  - cd ${TRAVIS_BUILD_DIR}/${DIR} && ./gradlew connectedCheck
+  - ./gradlew clean build
 
-after_script:
-  # Show tests and lint results
-  - cat ${TRAVIS_BUILD_DIR}/${DIR}/*/build/outputs/androidTest-results/connected/*
-  - cat ${TRAVIS_BUILD_DIR}/${DIR}/*/build/reports/lint-results.xml


### PR DESCRIPTION
This allows us to have some basic continuous integration for the Android app.

@xanscale @lorenzoPrimi  can you look to see why the `./gradlew clean build` is showing a lint error?