### PR TITLE
Copy explorer url

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,116 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -1,5 +1,7 @@
 package org.openobservatory.ooniprobe.activity;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -7,6 +9,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -244,6 +247,13 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                             .withTitle(getString(R.string.Modal_Error_LogNotFound))
                             .build().show(getSupportFragmentManager(), null);
                 }
+                return true;
+            case R.id.copyExplorerUrl:
+                String link = "https://explorer.ooni.io/measurement/" + measurement.report_id;
+                if (measurement.test_name.equals("web_connectivity"))
+                    link = link + "?input=" + measurement.url.url;
+                ((ClipboardManager) getSystemService(CLIPBOARD_SERVICE)).setPrimaryClip(ClipData.newPlainText(getString(R.string.General_AppName), link));
+                Toast.makeText(this, R.string.Toast_CopiedToClipboard, Toast.LENGTH_SHORT).show();
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -188,7 +188,9 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                     isInExplorer = true;
                 }
                 @Override
-                public void onError(String msg) {/* NOTHING */}
+                public void onError(String msg) {
+                    isInExplorer = false;
+                }
             });
         }
         load();
@@ -267,6 +269,13 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                 if (measurement.test_name.equals("web_connectivity"))
                     link = link + "?input=" + measurement.url.url;
                 ((ClipboardManager) getSystemService(CLIPBOARD_SERVICE)).setPrimaryClip(ClipData.newPlainText(getString(R.string.General_AppName), link));
+                if (isInExplorer)
+                    Toast.makeText(this, R.string.Toast_CopiedToClipboard, Toast.LENGTH_SHORT).show();
+                else {
+                    String toastStr = getString(R.string.Toast_CopiedToClipboard) + "\n" + getString(R.string.Toast_WillBeAvailable);
+                    Toast.makeText(this, toastStr, Toast.LENGTH_SHORT).show();
+
+                }
                 Toast.makeText(this, R.string.Toast_CopiedToClipboard, Toast.LENGTH_SHORT).show();
                 return true;
             default:

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -71,7 +71,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
     Toolbar toolbar;
     private Measurement measurement;
     private Snackbar snackbar;
-
+    private Boolean isInExplorer;
     public static Intent newIntent(Context context, int id) {
         return new Intent(context, MeasurementDetailActivity.class).putExtra(ID, id);
     }
@@ -178,12 +178,14 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
         snackbar = Snackbar.make(coordinatorLayout, R.string.Snackbar_ResultsNotUploaded_Text, Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.Snackbar_ResultsNotUploaded_Upload, v1 -> runAsyncTask());
         Context c = this;
+        isInExplorer = !measurement.hasReportFile(c);
         if (measurement.hasReportFile(c)){
             getApiClient().getMeasurement(measurement.report_id, null).enqueue(new GetMeasurementsCallback() {
                 @Override
                 public void onSuccess(ApiMeasurement.Result result) {
                     measurement.deleteEntryFile(c);
                     measurement.deleteLogFile(c);
+                    isInExplorer = true;
                 }
                 @Override
                 public void onError(String msg) {/* NOTHING */}

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -72,6 +72,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
     private Measurement measurement;
     private Snackbar snackbar;
     private Boolean isInExplorer;
+
     public static Intent newIntent(Context context, int id) {
         return new Intent(context, MeasurementDetailActivity.class).putExtra(ID, id);
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -177,6 +177,18 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                 .commit();
         snackbar = Snackbar.make(coordinatorLayout, R.string.Snackbar_ResultsNotUploaded_Text, Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.Snackbar_ResultsNotUploaded_Upload, v1 -> runAsyncTask());
+        Context c = this;
+        if (measurement.hasReportFile(c)){
+            getApiClient().getMeasurement(measurement.report_id, null).enqueue(new GetMeasurementsCallback() {
+                @Override
+                public void onSuccess(ApiMeasurement.Result result) {
+                    measurement.deleteEntryFile(c);
+                    measurement.deleteLogFile(c);
+                }
+                @Override
+                public void onError(String msg) {/* NOTHING */}
+            });
+        }
         load();
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
@@ -106,7 +106,7 @@ public class Measurement extends BaseModel implements Serializable {
 		List<Measurement> measurementsJson = new ArrayList<>();
 		List<Measurement> measurements = msmQuery.queryList();
 		for (Measurement measurement : measurements){
-			if (Measurement.getEntryFile(c, measurement.id, measurement.test_name).exists())
+			if (measurement.hasReportFile(c))
 				measurementsJson.add(measurement);
 		}
 		return measurementsJson;
@@ -122,6 +122,10 @@ public class Measurement extends BaseModel implements Serializable {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+	}
+
+	public Boolean hasReportFile(Context c){
+		return Measurement.getEntryFile(c, this.id, this.test_name).exists();
 	}
 
 	public static File getLogFile(Context c, int resultId, String test_name) {

--- a/app/src/main/res/menu/measurement.xml
+++ b/app/src/main/res/menu/measurement.xml
@@ -6,4 +6,7 @@
 	<item
 		android:id="@+id/viewLog"
 		android:title="@string/TestResults_Details_ViewLog" />
+	<item
+		android:id="@+id/copyExplorerUrl"
+		android:title="@string/TestResults_Details_CopyExplorerURL" />
 </menu>


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/856

## Proposed Changes

  - Calling the measurements url every time opening this screen (if json file is on disk) and delete it when published. Having in this case the “status” of the publishing of the measurement in this screen
  - Showing different messages if the measurement has been published or not
  - Copies the url to clipboard
