### PR TITLE
Refactor Notification in a class

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
@@ -22,6 +22,7 @@ import androidx.core.app.NotificationCompat;
 import com.airbnb.lottie.LottieAnimationView;
 
 import org.openobservatory.ooniprobe.R;
+import org.openobservatory.ooniprobe.common.NotificationService;
 import org.openobservatory.ooniprobe.model.database.Result;
 import org.openobservatory.ooniprobe.test.TestAsyncTask;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
@@ -33,7 +34,6 @@ import localhost.toolkit.app.fragment.MessageDialogFragment;
 
 public class RunningActivity extends AbstractActivity {
     private static final String TEST = "test";
-    private static final String TEST_RUN = "TEST_RUN";
     @BindView(R.id.name)
     TextView name;
     @BindView(R.id.log)
@@ -133,24 +133,8 @@ public class RunningActivity extends AbstractActivity {
             RunningActivity act = ref.get();
             if (act != null && !act.isFinishing()) {
                 if (act.background) {
-                    NotificationManager notificationManager = (NotificationManager) act.getSystemService(Context.NOTIFICATION_SERVICE);
-                    if (notificationManager != null && act.getPreferenceManager().isNotificationsCompletion()) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                            notificationManager.createNotificationChannel(new NotificationChannel(TEST_RUN, act.getString(R.string.Settings_Notifications_OnTestCompletion), NotificationManager.IMPORTANCE_DEFAULT));
-                        NotificationCompat.Builder b = new NotificationCompat.Builder(act, TEST_RUN);
-                        b.setAutoCancel(true);
-                        b.setDefaults(Notification.DEFAULT_ALL);
-                        Drawable d = act.getResources().getDrawable(act.testSuite.getIcon());
-                        Bitmap bitmap = Bitmap.createBitmap(d.getIntrinsicWidth(), d.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
-                        Canvas canvas = new Canvas(bitmap);
-                        d.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
-                        d.draw(canvas);
-                        b.setLargeIcon(bitmap);
-                        b.setSmallIcon(R.drawable.notification_icon);
-                        b.setContentTitle(act.getString(R.string.General_AppName));
-                        b.setContentText(act.getString(act.testSuite.getTitle()) + " " + act.getString(R.string.Notification_FinishedRunning));
-                        b.setContentIntent(PendingIntent.getActivity(act, 0, MainActivity.newIntent(act, R.id.testResults), PendingIntent.FLAG_UPDATE_CURRENT));
-                        notificationManager.notify(1, b.build());
+                    if(act.getPreferenceManager().isNotificationsCompletion()) {
+                        NotificationService.notifyTestEnded(act, act.testSuite);
                     }
                 } else
                     act.startActivity(MainActivity.newIntent(act, R.id.testResults));

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/NotificationService.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/NotificationService.java
@@ -1,0 +1,46 @@
+package org.openobservatory.ooniprobe.common;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+
+import androidx.core.app.NotificationCompat;
+
+import org.openobservatory.ooniprobe.R;
+import org.openobservatory.ooniprobe.activity.MainActivity;
+import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
+
+public class NotificationService {
+    private static final String TEST_RUN = "TEST_RUN";
+
+    public static void notifyTestEnded(Context c, AbstractSuite testSuite) {
+        sendNotification(c, c.getString(testSuite.getTitle()) + " " + c.getString(R.string.Notification_FinishedRunning), c.getResources().getDrawable(testSuite.getIcon()));
+    }
+
+    public static void sendNotification(Context c, String text, Drawable icon) {
+        NotificationManager notificationManager = (NotificationManager) c.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (notificationManager == null)
+            return;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            notificationManager.createNotificationChannel(new NotificationChannel(TEST_RUN, c.getString(R.string.Settings_Notifications_OnTestCompletion), NotificationManager.IMPORTANCE_DEFAULT));
+        NotificationCompat.Builder b = new NotificationCompat.Builder(c, TEST_RUN);
+        b.setAutoCancel(true);
+        b.setDefaults(Notification.DEFAULT_ALL);
+        Bitmap bitmap = Bitmap.createBitmap(icon.getIntrinsicWidth(), icon.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        icon.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        icon.draw(canvas);
+        b.setLargeIcon(bitmap);
+        b.setSmallIcon(R.drawable.notification_icon);
+        b.setContentTitle(c.getString(R.string.General_AppName));
+        b.setContentText(text);
+        b.setContentIntent(PendingIntent.getActivity(c, 0, MainActivity.newIntent(c, R.id.testResults), PendingIntent.FLAG_UPDATE_CURRENT));
+        notificationManager.notify(1, b.build());
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/NotificationService.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/NotificationService.java
@@ -27,8 +27,11 @@ public class NotificationService {
         NotificationManager notificationManager = (NotificationManager) c.getSystemService(Context.NOTIFICATION_SERVICE);
         if (notificationManager == null)
             return;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            notificationManager.createNotificationChannel(new NotificationChannel(TEST_RUN, c.getString(R.string.Settings_Notifications_OnTestCompletion), NotificationManager.IMPORTANCE_DEFAULT));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationManager.createNotificationChannel(
+                    new NotificationChannel(TEST_RUN, c.getString(R.string.Settings_Notifications_OnTestCompletion), NotificationManager.IMPORTANCE_DEFAULT)
+            );
+        }
         NotificationCompat.Builder b = new NotificationCompat.Builder(c, TEST_RUN);
         b.setAutoCancel(true);
         b.setDefaults(Notification.DEFAULT_ALL);


### PR DESCRIPTION
I moved the `sendNotificaiton` function in a separate class.
This will help the future implementation of automatic testing in background.
I refactored the `sendNotification` function to be as generic as possible and get a text and an icon, while the `notifyTestEnded` function gets a testSuite and from that will generate text and icon.