### PR TITLE
Delete Json and Log files on Rerun

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
@@ -49,8 +49,7 @@ public class FailedFragment extends Fragment {
 		AbstractSuite testSuite = failedMeasurement.result.getTestSuite();
 		testSuite.setTestList(abstractTest);
 		testSuite.setResult(failedMeasurement.result);
-		failedMeasurement.is_rerun = true;
-		failedMeasurement.save();
+		failedMeasurement.setReRun(getContext());
 		Intent intent = RunningActivity.newIntent((AbstractActivity) getActivity(), testSuite);
 		if (intent != null) {
 			startActivity(intent);

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
@@ -211,4 +211,11 @@ public class Measurement extends BaseModel implements Serializable {
 			});
 		}
 	}
+
+	public void setReRun(Context c){
+		this.deleteEntryFile(c);
+		this.deleteLogFile(c);
+		this.is_rerun = true;
+		this.save();
+	}
 }


### PR DESCRIPTION
In iOS we delete JSON and Log file when we re_run a test.
https://github.com/ooni/probe-ios/blob/master/ooniprobe/Model/Database/Measurement.mm#L90
I noticed this doesn't happen in Android and I recreated the same function.