### PR TITLE
Calling delete json on app start

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -13,6 +13,7 @@ import org.openobservatory.ooniprobe.BuildConfig;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.client.OONIAPIClient;
 import org.openobservatory.ooniprobe.client.OONIOrchestraClient;
+import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.jsonresult.TestKeys;
 
 import java.io.File;
@@ -47,6 +48,9 @@ public class Application extends android.app.Application {
 		FlavorApplication.onCreate(this, preferenceManager.isSendCrash());
 		if (BuildConfig.DEBUG)
 			FlowLog.setMinimumLoggingLevel(FlowLog.Level.V);
+		if (preferenceManager.canCallDeleteJson())
+			Measurement.deleteUploadedJsons(this);
+
 	}
 
 	public OkHttpClient getOkHttpClient() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
@@ -15,6 +15,9 @@ public class PreferenceManager {
 	private static final String IS_MANUAL_UPLOAD_DIALOG = "isManualUploadDialog";
 	private static final String TOKEN = "token";
 	private static final String SHOW_ONBOARDING = "first_run";
+	private final Integer DELETE_JSON_DELAY = 86400;
+	private final String DELETE_JSON_KEY = "deleteUploadedJsons";
+
 	private final SharedPreferences sp;
 	private final Resources r;
 
@@ -172,4 +175,21 @@ public class PreferenceManager {
 				count++;
 		return count;
 	}
+
+	public boolean canCallDeleteJson(){
+		long lastCalled = sp.getLong(DELETE_JSON_KEY, 0);
+
+		if (lastCalled == 0)
+			return true;
+
+		if (System.currentTimeMillis() - lastCalled > DELETE_JSON_DELAY){
+			return true;
+		}
+		return false;
+	}
+
+	public void setLastCalled(){
+		sp.edit().putLong(DELETE_JSON_KEY, System.currentTimeMillis()).apply();
+	}
+
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
@@ -16,6 +16,7 @@ import com.raizlabs.android.dbflow.structure.BaseModel;
 
 import org.openobservatory.ooniprobe.client.callback.GetMeasurementsCallback;
 import org.openobservatory.ooniprobe.common.Application;
+import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.model.api.ApiMeasurement;
 import org.openobservatory.ooniprobe.model.jsonresult.TestKeys;
 import org.openobservatory.ooniprobe.test.test.AbstractTest;
@@ -193,7 +194,8 @@ public class Measurement extends BaseModel implements Serializable {
 		test_keys = new Gson().toJson(testKeys);
 	}
 
-	public void deleteUploadedJsons(Application a){
+	public static void deleteUploadedJsons(Application a){
+		PreferenceManager pm = a.getPreferenceManager();
 		List<Measurement> measurements = Measurement.selectMeasurementsWithJson(a);
 		for (int i = 0; i < measurements.size(); i++) {
 			Measurement measurement = measurements.get(i);
@@ -210,6 +212,7 @@ public class Measurement extends BaseModel implements Serializable {
 				}
 			});
 		}
+		pm.setLastCalled();
 	}
 
 	public void setReRun(Context c){


### PR DESCRIPTION
The function to delete Jsons was never called in Android on app start, only when entering the measurement page.
I'm unifying this code with the iOS one, ref:
https://github.com/ooni/probe-ios/blob/master/ooniprobe/Utility/TestUtility.mm#L198
https://github.com/ooni/probe-ios/blob/master/ooniprobe/Utility/TestUtility.mm#L189
https://github.com/ooni/probe-ios/blob/master/ooniprobe/AppDelegate.mm#L179