### PR TITLE
Upload reason failure

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -251,6 +251,8 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
     public void onConfirmation(Serializable extra, int buttonClicked) {
         if (buttonClicked == DialogInterface.BUTTON_POSITIVE)
             runAsyncTask();
+        //else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
+        //TODO
     }
 
     private static class ResubmitAsyncTask extends ResubmitTask<MeasurementDetailActivity> {
@@ -271,6 +273,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                             .withTitle(activity.getString(R.string.Modal_UploadFailed_Title))
                             .withMessage(activity.getString(R.string.Modal_UploadFailed_Paragraph, errors.toString(), totUploads.toString()))
                             .withPositiveButton(activity.getString(R.string.Modal_Retry))
+                            .withNeutralButton(getActivity().getString(R.string.Modal_DisplayFailureLog))
                             .build().show(activity.getSupportFragmentManager(), null);
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -253,6 +253,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
             runAsyncTask();
         //else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
         //TODO
+        //startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, measurement));
     }
 
     private static class ResubmitAsyncTask extends ResubmitTask<MeasurementDetailActivity> {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -252,7 +252,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
         if (buttonClicked == DialogInterface.BUTTON_POSITIVE)
             runAsyncTask();
         else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
-            startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, "HELLO"));
+            startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, (String)extra));
     }
 
     private static class ResubmitAsyncTask extends ResubmitTask<MeasurementDetailActivity> {
@@ -274,6 +274,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                             .withMessage(activity.getString(R.string.Modal_UploadFailed_Paragraph, errors.toString(), totUploads.toString()))
                             .withPositiveButton(activity.getString(R.string.Modal_Retry))
                             .withNeutralButton(getActivity().getString(R.string.Modal_DisplayFailureLog))
+                            .withExtra(logs)
                             .build().show(activity.getSupportFragmentManager(), null);
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -251,9 +251,8 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
     public void onConfirmation(Serializable extra, int buttonClicked) {
         if (buttonClicked == DialogInterface.BUTTON_POSITIVE)
             runAsyncTask();
-        //else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
-        //TODO
-        //startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, measurement));
+        else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
+            startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, "HELLO"));
     }
 
     private static class ResubmitAsyncTask extends ResubmitTask<MeasurementDetailActivity> {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
@@ -136,9 +136,8 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
     public void onConfirmation(Serializable extra, int buttonClicked) {
         if (buttonClicked == DialogInterface.BUTTON_POSITIVE)
             runAsyncTask();
-        //else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
-        //TODO
-        startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, measurement));
+        else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
+            startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, "HELLO"));
     }
 
     private static class ResubmitAsyncTask extends ResubmitTask<ResultDetailActivity> {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
@@ -138,6 +138,7 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
             runAsyncTask();
         //else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
         //TODO
+        startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, measurement));
     }
 
     private static class ResubmitAsyncTask extends ResubmitTask<ResultDetailActivity> {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
@@ -136,6 +136,8 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
     public void onConfirmation(Serializable extra, int buttonClicked) {
         if (buttonClicked == DialogInterface.BUTTON_POSITIVE)
             runAsyncTask();
+        //else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
+        //TODO
     }
 
     private static class ResubmitAsyncTask extends ResubmitTask<ResultDetailActivity> {
@@ -155,6 +157,7 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
                             .withTitle(getActivity().getString(R.string.Modal_UploadFailed_Title))
                             .withMessage(getActivity().getString(R.string.Modal_UploadFailed_Paragraph, errors.toString(), totUploads.toString()))
                             .withPositiveButton(getActivity().getString(R.string.Modal_Retry))
+                            .withNeutralButton(getActivity().getString(R.string.Modal_DisplayFailureLog))
                             .build().show(getActivity().getSupportFragmentManager(), null);
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
@@ -137,7 +137,7 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
         if (buttonClicked == DialogInterface.BUTTON_POSITIVE)
             runAsyncTask();
         else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
-            startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, "HELLO"));
+            startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, (String)extra));
     }
 
     private static class ResubmitAsyncTask extends ResubmitTask<ResultDetailActivity> {
@@ -158,6 +158,7 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
                             .withMessage(getActivity().getString(R.string.Modal_UploadFailed_Paragraph, errors.toString(), totUploads.toString()))
                             .withPositiveButton(getActivity().getString(R.string.Modal_Retry))
                             .withNeutralButton(getActivity().getString(R.string.Modal_DisplayFailureLog))
+                            .withExtra(logs)
                             .build().show(getActivity().getSupportFragmentManager(), null);
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/TextActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/TextActivity.java
@@ -58,7 +58,6 @@ public class TextActivity extends AbstractActivity {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.text);
 		ButterKnife.bind(this);
-		measurement = (Measurement) getIntent().getSerializableExtra(TEST);
 		showText();
 	}
 
@@ -81,12 +80,15 @@ public class TextActivity extends AbstractActivity {
 	public void showText(){
 		switch (getIntent().getIntExtra(TYPE, 0)) {
 			case TYPE_JSON:
+				measurement = (Measurement) getIntent().getSerializableExtra(TEST);
 				showJson();
 				break;
 			case TYPE_LOG:
+				measurement = (Measurement) getIntent().getSerializableExtra(TEST);
 				showLog();
 				break;
 			case TYPE_UPLOAD_LOG:
+				text = (String) getIntent().getSerializableExtra(TEXT);
 				showUploadLog();
 				break;
 		}

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/TextActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/TextActivity.java
@@ -148,7 +148,7 @@ public class TextActivity extends AbstractActivity {
 	}
 
 	private void showUploadLog(){
-
+		textView.setText(text);
 	}
 
 	private void showError(String msg){

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/TextActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/TextActivity.java
@@ -39,13 +39,19 @@ public class TextActivity extends AbstractActivity {
 	private String text;
 	public static final int TYPE_LOG = 1;
 	public static final int TYPE_JSON = 2;
+	public static final int TYPE_UPLOAD_LOG = 3;
 	private static final String TEST = "test";
 	private static final String TYPE = "type";
+	private static final String TEXT = "text";
 	@BindView(R.id.textView)
 	TextView textView;
 
 	public static Intent newIntent(Context context, int type, Measurement measurement) {
 		return new Intent(context, TextActivity.class).putExtra(TYPE, type).putExtra(TEST, measurement);
+	}
+
+	public static Intent newIntent(Context context, int type, String text) {
+		return new Intent(context, TextActivity.class).putExtra(TYPE, type).putExtra(TEXT, text);
 	}
 
 	@Override protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -75,36 +81,55 @@ public class TextActivity extends AbstractActivity {
 	public void showText(){
 		switch (getIntent().getIntExtra(TYPE, 0)) {
 			case TYPE_JSON:
-				//Try to open file, if it doesn't exist dont show Error dialog immediately but try to download the json from internet
-				try {
-					File entryFile = Measurement.getEntryFile(this, measurement.id, measurement.test_name);
-					String json = FileUtils.readFileToString(entryFile, Charset.forName("UTF-8"));
-					text = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(new JsonParser().parse(json));
-					textView.setText(text);
-				} catch (Exception e) {
-					e.printStackTrace();
-					if (ReachabilityManager.getNetworkType(this).equals(ReachabilityManager.NO_INTERNET)) {
-						new MessageDialogFragment.Builder()
-								.withTitle(getString(R.string.Modal_Error))
-								.withMessage(getString(R.string.Modal_Error_RawDataNoInternet))
-								.build().show(getSupportFragmentManager(), null);
-						return;
-					}
-					getApiClient().getMeasurement(measurement.report_id, null).enqueue(new GetMeasurementsCallback() {
+				showJson();
+				break;
+			case TYPE_LOG:
+				showLog();
+				break;
+			case TYPE_UPLOAD_LOG:
+				showUploadLog();
+				break;
+		}
+	}
+
+	private void showLog(){
+		try {
+			File logFile = Measurement.getLogFile(this, measurement.result.id, measurement.test_name);
+			String log = FileUtils.readFileToString(logFile, Charset.forName("UTF-8"));
+			text = log;
+			textView.setText(log);
+		} catch (Exception e) {
+			new MessageDialogFragment.Builder()
+					.withTitle(getString(R.string.Modal_Error_LogNotFound))
+					.build().show(getSupportFragmentManager(), null);
+		}
+	}
+
+	private void showJson(){
+		//Try to open file, if it doesn't exist dont show Error dialog immediately but try to download the json from internet
+		try {
+			File entryFile = Measurement.getEntryFile(this, measurement.id, measurement.test_name);
+			String json = FileUtils.readFileToString(entryFile, Charset.forName("UTF-8"));
+			text = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(new JsonParser().parse(json));
+			textView.setText(text);
+		} catch (Exception e) {
+			e.printStackTrace();
+			if (ReachabilityManager.getNetworkType(this).equals(ReachabilityManager.NO_INTERNET)) {
+				new MessageDialogFragment.Builder()
+						.withTitle(getString(R.string.Modal_Error))
+						.withMessage(getString(R.string.Modal_Error_RawDataNoInternet))
+						.build().show(getSupportFragmentManager(), null);
+				return;
+			}
+			getApiClient().getMeasurement(measurement.report_id, null).enqueue(new GetMeasurementsCallback() {
+				@Override
+				public void onSuccess(ApiMeasurement.Result result) {
+					//Download measurement data locally and displaying into the TextView
+					getOkHttpClient().newCall(new Request.Builder().url(result.measurement_url).build()).enqueue(new GetMeasurementJsonCallback() {
 						@Override
-						public void onSuccess(ApiMeasurement.Result result) {
-							//Download measurement data locally and displaying into the TextView
-							getOkHttpClient().newCall(new Request.Builder().url(result.measurement_url).build()).enqueue(new GetMeasurementJsonCallback() {
-								@Override
-								public void onSuccess(String json) {
-									text = json;
-									textView.setText(json);
-								}
-								@Override
-								public void onError(String msg) {
-									showError(msg);
-								}
-							});
+						public void onSuccess(String json) {
+							text = json;
+							textView.setText(json);
 						}
 						@Override
 						public void onError(String msg) {
@@ -112,20 +137,16 @@ public class TextActivity extends AbstractActivity {
 						}
 					});
 				}
-				break;
-			case TYPE_LOG:
-				try {
-					File logFile = Measurement.getLogFile(this, measurement.result.id, measurement.test_name);
-					String log = FileUtils.readFileToString(logFile, Charset.forName("UTF-8"));
-					text = log;
-					textView.setText(log);
-				} catch (Exception e) {
-					new MessageDialogFragment.Builder()
-							.withTitle(getString(R.string.Modal_Error_LogNotFound))
-							.build().show(getSupportFragmentManager(), null);
+				@Override
+				public void onError(String msg) {
+					showError(msg);
 				}
-				break;
+			});
 		}
+	}
+
+	private void showUploadLog(){
+
 	}
 
 	private void showError(String msg){

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
@@ -18,6 +18,7 @@ import org.openobservatory.ooniprobe.model.database.Measurement_Table;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.ooni.mk.MKReporterResults;
@@ -30,6 +31,7 @@ public class ResubmitTask<A extends AppCompatActivity> extends NetworkProgressAs
     private MKReporterTask task;
     protected Integer totUploads;
     protected Integer errors;
+    protected String logs;
 
     /**
      * Use this class to resubmit a measurement, use result_id and measurement_id to filter list of value
@@ -65,8 +67,11 @@ public class ResubmitTask<A extends AppCompatActivity> extends NetworkProgressAs
             m.save();
         } else {
             Log.w(MKReporterTask.class.getSimpleName(), results.getLogs());
-            // TODO decide what to do with logs (append on log file?)
         }
+        System.out.println("getReason "+ results.getReason());
+        System.out.println("getLogs "+ results.getLogs());
+        if (!results.isGood())
+            logs += results.getReason() + "\n";
         return results.isGood();
     }
 
@@ -91,6 +96,7 @@ public class ResubmitTask<A extends AppCompatActivity> extends NetworkProgressAs
      */
     @Override
     protected Boolean doInBackground(Integer... params) {
+        logs = "";
         errors = 0;
         if (params.length != 2)
             throw new IllegalArgumentException("MKCollectorResubmitTask requires 2 nullable params: result_id, measurement_id");

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -29,6 +29,7 @@ import com.raizlabs.android.dbflow.sql.language.SQLite;
 
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.activity.ResultDetailActivity;
+import org.openobservatory.ooniprobe.activity.TextActivity;
 import org.openobservatory.ooniprobe.common.Application;
 import org.openobservatory.ooniprobe.common.ResubmitTask;
 import org.openobservatory.ooniprobe.item.DateItem;
@@ -221,6 +222,7 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
                 new ResubmitAsyncTask(this).execute(null, null);
             //else if (i == DialogInterface.BUTTON_NEUTRAL)
                 //TODO
+            startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, measurement));
             else
                 snackbar.show();
         } else if (i == DialogInterface.BUTTON_POSITIVE) {

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -221,7 +221,7 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
             if (i == DialogInterface.BUTTON_POSITIVE)
                 new ResubmitAsyncTask(this).execute(null, null);
             else if (i == DialogInterface.BUTTON_NEUTRAL)
-                startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, "HELLO"));
+                startActivity(TextActivity.newIntent(getActivity(), TextActivity.TYPE_UPLOAD_LOG, (String)serializable));
             else
                 snackbar.show();
         } else if (i == DialogInterface.BUTTON_POSITIVE) {
@@ -253,6 +253,7 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
                             .withMessage(getActivity().getString(R.string.Modal_UploadFailed_Paragraph, errors.toString(), totUploads.toString()))
                             .withPositiveButton(getActivity().getString(R.string.Modal_Retry))
                             .withNeutralButton(getActivity().getString(R.string.Modal_DisplayFailureLog))
+                            .withExtra(logs)
                             .build().show(getActivity().getSupportFragmentManager(), null);
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -219,6 +219,8 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
         if (serializable.equals(R.string.Modal_ResultsNotUploaded_Title)) {
             if (i == DialogInterface.BUTTON_POSITIVE)
                 new ResubmitAsyncTask(this).execute(null, null);
+            //else if (i == DialogInterface.BUTTON_NEUTRAL)
+                //TODO
             else
                 snackbar.show();
         } else if (i == DialogInterface.BUTTON_POSITIVE) {
@@ -249,6 +251,7 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
                             .withTitle(getActivity().getString(R.string.Modal_UploadFailed_Title))
                             .withMessage(getActivity().getString(R.string.Modal_UploadFailed_Paragraph, errors.toString(), totUploads.toString()))
                             .withPositiveButton(getActivity().getString(R.string.Modal_Retry))
+                            .withNeutralButton(getActivity().getString(R.string.Modal_DisplayFailureLog))
                             .build().show(getActivity().getSupportFragmentManager(), null);
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -220,9 +220,8 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
         if (serializable.equals(R.string.Modal_ResultsNotUploaded_Title)) {
             if (i == DialogInterface.BUTTON_POSITIVE)
                 new ResubmitAsyncTask(this).execute(null, null);
-            //else if (i == DialogInterface.BUTTON_NEUTRAL)
-                //TODO
-            startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, measurement));
+            else if (i == DialogInterface.BUTTON_NEUTRAL)
+                startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, "HELLO"));
             else
                 snackbar.show();
         } else if (i == DialogInterface.BUTTON_POSITIVE) {


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/919

I think the three activities (and fragment)
`ResultDetailActivity`
`ResultListFragment`
and `MeasurementDetailActivity`
have some code shared between them, in particular the `ResubmitAsyncTask` and the retry popup.

I tried to refactor some code to remove redundancy but I failed, I'm not confident enough to touch this code at this stage and revamping it would be at least an `effort/L` if not `effort/XL` so I'll open a ticket to track this issue while pushing only basic changes at the moment.

This has been tested “thanks” to this bug https://github.com/ooni/probe/issues/899 