### PR TITLE
Created exception utility

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ExceptionManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ExceptionManager.java
@@ -1,0 +1,12 @@
+package org.openobservatory.ooniprobe.common;
+
+public class ExceptionManager {
+    /*
+//TODO
+- add sentry
+- call this class in the code (Crashlytics.logException)
+*/
+    public void logException(Exception e){
+        Crashlytics.logException(e);
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ExceptionManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ExceptionManager.java
@@ -1,12 +1,7 @@
 package org.openobservatory.ooniprobe.common;
 
 public class ExceptionManager {
-    /*
-//TODO
-- add sentry
-- call this class in the code (Crashlytics.logException)
-*/
-    public void logException(Exception e){
+    public static void logException(Exception e){
         Crashlytics.logException(e);
     }
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
@@ -5,7 +5,7 @@ import android.os.AsyncTask;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.activity.AbstractActivity;
 import org.openobservatory.ooniprobe.common.Application;
-import org.openobservatory.ooniprobe.common.Crashlytics;
+import org.openobservatory.ooniprobe.common.ExceptionManager;
 import org.openobservatory.ooniprobe.model.api.UrlList;
 import org.openobservatory.ooniprobe.model.database.Result;
 import org.openobservatory.ooniprobe.model.database.Url;
@@ -60,7 +60,7 @@ public class TestAsyncTask<ACT extends AbstractActivity> extends AsyncTask<Abstr
 					boolean okay = MKResourcesManager.maybeUpdateResources(act);
 					if (!okay) {
 						Exception e = new Exception("MKResourcesManager didn't find resources");
-						Crashlytics.logException(e);
+						ExceptionManager.logException(e);
 						throw e;
 					}
 					geoIPLookup.setCABundlePath(MKResourcesManager.getCABundlePath(act));

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -12,7 +12,7 @@ import androidx.annotation.StringRes;
 import com.google.gson.Gson;
 
 import org.apache.commons.io.FileUtils;
-import org.openobservatory.ooniprobe.common.Crashlytics;
+import org.openobservatory.ooniprobe.common.ExceptionManager;
 import org.openobservatory.ooniprobe.common.MKException;
 import org.openobservatory.ooniprobe.common.OrchestraTask;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
@@ -68,7 +68,7 @@ public abstract class AbstractTest implements Serializable {
             }
         } catch (Exception e) {
             e.printStackTrace();
-            Crashlytics.logException(e);
+            ExceptionManager.logException(e);
             return;
         }
         settings.name = mkName;
@@ -155,7 +155,7 @@ public abstract class AbstractTest implements Serializable {
                         setFailureMsg(event.value, result);
                         break;
                     case "bug.json_dump":
-                        Crashlytics.logException(new MKException(event));
+                        ExceptionManager.logException(new MKException(event));
                         break;
                     default:
                         Log.w(UNUSED_KEY, event.key);
@@ -163,7 +163,7 @@ public abstract class AbstractTest implements Serializable {
                 }
             } catch (Exception e) {
                 e.printStackTrace();
-                Crashlytics.logException(e);
+                ExceptionManager.logException(e);
             }
     }
 


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/983 

## Proposed Changes

  - Created a class called ExceptionManager that imports Crashlytics and sends crash to them.
In this way if we decide to remove Crashlytics and use any other crash reporting system in the code, it will be a one line edit.