### PR TITLE
Fixing text overlap in preference screen

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/PreferenceFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/PreferenceFragment.java
@@ -113,7 +113,9 @@ public class PreferenceFragment extends ExtendedPreferenceFragment<PreferenceFra
                         .withMessage(getString(R.string.Modal_OnlyDigits))
                         .build().show(getFragmentManager(), null);
                 sharedPreferences.edit().remove(key).apply();
-                getFragmentManager().beginTransaction().replace(android.R.id.content, newConcreteInstance(rootKey)).commit();
+                EditTextPreference p = (EditTextPreference) findPreference(key);
+                if (p != null)
+                    p.setText("");
             }
         } else if (preference instanceof SwitchPreferenceCompat) {
             //Not executing this code in case of max_runtime_enabled. See below.
@@ -129,7 +131,9 @@ public class PreferenceFragment extends ExtendedPreferenceFragment<PreferenceFra
                         .withMessage(getString(R.string.Modal_EnableAtLeastOneTest))
                         .build().show(getFragmentManager(), null);
                 sharedPreferences.edit().remove(key).apply();
-                getFragmentManager().beginTransaction().replace(android.R.id.content, newConcreteInstance(rootKey)).commit();
+                SwitchPreferenceCompat p = (SwitchPreferenceCompat) findPreference(key);
+                if (p != null)
+                    p.setChecked(true);
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/918

## Proposed Changes

  - The problem was not the modal but the invasive way to refresh the entire preferenceFragment
  - I opted for a simpler solution to only refresh the affected field

Ref: https://stackoverflow.com/questions/26335068/how-to-reject-a-change-in-onsharedpreferencechanged-listener
