### PR TITLE
Sort results in the order they ran

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
@@ -49,6 +49,7 @@ import org.openobservatory.ooniprobe.test.test.WebConnectivity;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -167,7 +168,12 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
         result = SQLite.select().from(Result.class).where(Result_Table.id.eq(result.id)).querySingle();
         assert result != null;
         items.clear();
-        for (Measurement measurement : result.getMeasurements())
+        List<Measurement> measurements;
+        if (result.test_group_name.equals("websites"))
+            measurements = result.getMeasurementsSorted();
+        else
+            measurements = result.getMeasurements();
+        for (Measurement measurement : measurements)
             items.add((measurement.test_name.equals(Ndt.NAME) || measurement.test_name.equals(Dash.NAME))
                     && !measurement.is_failed ?
                     new MeasurementPerfItem(measurement, this) :

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Result.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Result.java
@@ -74,6 +74,12 @@ public class Result extends BaseModel implements Serializable {
 
 	public List<Measurement> getMeasurements() {
 		if (measurements == null)
+			measurements = SQLite.select().from(Measurement.class).where(Measurement_Table.result_id.eq(id), Measurement_Table.is_rerun.eq(false), Measurement_Table.is_done.eq(true)).orderBy(Measurement_Table.id, true).queryList();
+		return measurements;
+	}
+
+	public List<Measurement> getMeasurementsSorted() {
+		if (measurements == null)
 			measurements = SQLite.select().from(Measurement.class).where(Measurement_Table.result_id.eq(id), Measurement_Table.is_rerun.eq(false), Measurement_Table.is_done.eq(true)).orderBy(Measurement_Table.is_anomaly, false).orderBy(Measurement_Table.is_failed, false).orderBy(Measurement_Table.id, true).queryList();
 		return measurements;
 	}


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/1153

A new method measurementsSorted has been added that is gonna be used only when displaying website result rows.