### PR TITLE
Remove logs more effectively on app start

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -194,7 +194,6 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                 @Override
                 public void onSuccess(ApiMeasurement.Result result) {
                     measurement.deleteEntryFile(c);
-                    measurement.deleteLogFileAfterAWeek(c);
                     isInExplorer = true;
                 }
                 @Override

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -9,6 +9,7 @@ import com.raizlabs.android.dbflow.config.FlowManager;
 import org.openobservatory.ooniprobe.BuildConfig;
 import org.openobservatory.ooniprobe.client.OONIAPIClient;
 import org.openobservatory.ooniprobe.client.OONIOrchestraClient;
+import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.jsonresult.TestKeys;
 
 import java.io.IOException;
@@ -46,7 +47,7 @@ public class Application extends android.app.Application {
 		// Code commented to prevent callling API on app start
 		//if (preferenceManager.canCallDeleteJson())
 		//	Measurement.deleteUploadedJsons(this);
-
+		Measurement.deleteOldLogs(this);
 	}
 
 	public OkHttpClient getOkHttpClient() {


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/1212

## Proposed Changes

  - Not calling remove log tied to the report file
  - Creating a new function that returns all measurement with log files
  - Calling this function on app start and removing logs more than 7 days old
