### PR TITLE
Check and delete Uploaded report files with the new api

### DIFF
--- a/app/src/androidTest/java/org/openobservatory/ooniprobe/client/OONIAPIClientTest.java
+++ b/app/src/androidTest/java/org/openobservatory/ooniprobe/client/OONIAPIClientTest.java
@@ -6,6 +6,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openobservatory.ooniprobe.AbstractTest;
+import org.openobservatory.ooniprobe.client.callback.CheckReportIdCallback;
 import org.openobservatory.ooniprobe.client.callback.GetMeasurementJsonCallback;
 import org.openobservatory.ooniprobe.client.callback.GetMeasurementsCallback;
 import org.openobservatory.ooniprobe.model.api.ApiMeasurement;
@@ -76,15 +77,27 @@ public class OONIAPIClientTest extends AbstractTest {
 
     @Test
     public void testSelectMeasurementsWithJson() throws IOException {
+        final CountDownLatch signal = new CountDownLatch(1);
         Delete.table(Measurement.class);
         addMeasurement(EXISTING_REPORT_ID, false);
-        addMeasurement(EXISTING_REPORT_ID_2, true);
-        addMeasurement(NONEXISTING_REPORT_ID, true);
-        List<Measurement> measurements = Measurement.selectMeasurementsWithJson(a);
-        //I create 3 measurement and only two of them have a file on disk
-        Assert.assertTrue(measurements.size() == 2 &&
-            containsMeasurement(measurements, NONEXISTING_REPORT_ID) &&
-            containsMeasurement(measurements, EXISTING_REPORT_ID_2));
+        a.getApiClient().checkReportId(EXISTING_REPORT_ID).enqueue(new CheckReportIdCallback() {
+            @Override
+            public void onSuccess(Boolean found) {
+                Assert.assertTrue(found);
+                signal.countDown();
+            }
+
+            @Override
+            public void onError(String msg) {
+                signal.countDown();
+            }
+        });
+        try {
+            signal.await(1, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
     }
 
     private Boolean containsMeasurement(List<Measurement> measurements, String report_id){

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -21,7 +21,7 @@ import com.google.android.material.snackbar.Snackbar;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 
 import org.openobservatory.ooniprobe.R;
-import org.openobservatory.ooniprobe.client.callback.GetMeasurementsCallback;
+import org.openobservatory.ooniprobe.client.callback.CheckReportIdCallback;
 import org.openobservatory.ooniprobe.common.ResubmitTask;
 import org.openobservatory.ooniprobe.fragment.measurement.DashFragment;
 import org.openobservatory.ooniprobe.fragment.measurement.FacebookMessengerFragment;
@@ -37,7 +37,6 @@ import org.openobservatory.ooniprobe.fragment.measurement.TorFragment;
 import org.openobservatory.ooniprobe.fragment.measurement.WebConnectivityFragment;
 import org.openobservatory.ooniprobe.fragment.measurement.WhatsappFragment;
 import org.openobservatory.ooniprobe.fragment.resultHeader.ResultHeaderDetailFragment;
-import org.openobservatory.ooniprobe.model.api.ApiMeasurement;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.database.Measurement_Table;
 import org.openobservatory.ooniprobe.test.suite.PerformanceSuite;
@@ -189,12 +188,12 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
         Context c = this;
         isInExplorer = !measurement.hasReportFile(c);
         if (measurement.hasReportFile(c)){
-            //measurement.getUrlString will return null when the measurement is not a web_connectivity
-            getApiClient().getMeasurement(measurement.report_id, measurement.getUrlString()).enqueue(new GetMeasurementsCallback() {
+            getApiClient().checkReportId(measurement.report_id).enqueue(new CheckReportIdCallback() {
                 @Override
-                public void onSuccess(ApiMeasurement.Result result) {
-                    measurement.deleteEntryFile(c);
-                    isInExplorer = true;
+                public void onSuccess(Boolean found) {
+                    if (found)
+                        Measurement.deleteMeasurementWithReportId(c, measurement.report_id);
+                    isInExplorer = found;
                 }
                 @Override
                 public void onError(String msg) {

--- a/app/src/main/java/org/openobservatory/ooniprobe/client/OONIAPIClient.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/client/OONIAPIClient.java
@@ -9,4 +9,7 @@ import retrofit2.http.Query;
 public interface OONIAPIClient {
 	@GET("api/v1/measurements")
 	Call<ApiMeasurement> getMeasurement(@Query("report_id") String report_id, @Query("input") String input);
+
+	@GET("api/_/check_report_id")
+	Call<ApiMeasurement> checkReportId(@Query("report_id") String report_id);
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/client/callback/CheckReportIdCallback.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/client/callback/CheckReportIdCallback.java
@@ -1,0 +1,28 @@
+package org.openobservatory.ooniprobe.client.callback;
+
+import org.openobservatory.ooniprobe.R;
+import org.openobservatory.ooniprobe.model.api.ApiMeasurement;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public abstract class CheckReportIdCallback implements Callback<ApiMeasurement> {
+    @Override
+    public void onResponse(Call<ApiMeasurement> call, Response<ApiMeasurement> response) {
+        if (response.isSuccessful() && response.body() != null) {
+            onSuccess(response.body().found);
+        } else {
+            onError(Integer.toString(R.string.Modal_Error_JsonEmpty));
+        }
+    }
+
+    @Override
+    public void onFailure(Call<ApiMeasurement> call, Throwable t) {
+        onError(t.getMessage());
+    }
+
+    public abstract void onSuccess(Boolean found);
+
+    public abstract void onError(String msg);
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -44,9 +44,8 @@ public class Application extends android.app.Application {
 		FlavorApplication.onCreate(this, preferenceManager.isSendCrash());
 		if (BuildConfig.DEBUG)
 			FlowLog.setMinimumLoggingLevel(FlowLog.Level.V);
-		// Code commented to prevent callling API on app start
-		//if (preferenceManager.canCallDeleteJson())
-		//	Measurement.deleteUploadedJsons(this);
+		if (preferenceManager.canCallDeleteJson())
+			Measurement.deleteUploadedJsons(this);
 		Measurement.deleteOldLogs(this);
 	}
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/api/ApiMeasurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/api/ApiMeasurement.java
@@ -5,6 +5,7 @@ import java.util.List;
 public class ApiMeasurement {
     public Metadata metadata;
     public List<Result> results = null;
+    public Boolean found;
 
     public class Metadata {
         public Integer count;
@@ -28,4 +29,5 @@ public class ApiMeasurement {
         public String report_id;
         public String test_name;
     }
+
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
@@ -14,7 +14,7 @@ import com.raizlabs.android.dbflow.sql.language.SQLite;
 import com.raizlabs.android.dbflow.sql.language.Where;
 import com.raizlabs.android.dbflow.structure.BaseModel;
 
-import org.openobservatory.ooniprobe.client.callback.GetMeasurementsCallback;
+import org.openobservatory.ooniprobe.client.callback.CheckReportIdCallback;
 import org.openobservatory.ooniprobe.common.AppDatabase;
 import org.openobservatory.ooniprobe.common.Application;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
@@ -36,7 +36,9 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Table(database = AppDatabase.class)
 public class Measurement extends BaseModel implements Serializable {
@@ -112,15 +114,19 @@ public class Measurement extends BaseModel implements Serializable {
 		return Measurement.selectUploadable().and(Measurement_Table.result_id.eq(resultId));
 	}
 
-	public static List<Measurement> selectMeasurementsWithJson(Context c) {
+	public static Where<Measurement> selectWithReportId(String report_id) {
+		return Measurement.selectUploaded().and(Measurement_Table.report_id.eq(report_id));
+	}
+
+	public static Set<String> getReportsUploaded(Context c) {
 		Where<Measurement> msmQuery = Measurement.selectUploaded();
-		List<Measurement> measurementsJson = new ArrayList<>();
+		Set<String> reportIds = new HashSet<>();
 		List<Measurement> measurements = msmQuery.queryList();
 		for (Measurement measurement : measurements){
 			if (measurement.hasReportFile(c))
-				measurementsJson.add(measurement);
+				reportIds.add(measurement.report_id);
 		}
-		return measurementsJson;
+		return reportIds;
 	}
 
 	public static List<Measurement> selectMeasurementsWithLog(Context c) {
@@ -235,14 +241,13 @@ public class Measurement extends BaseModel implements Serializable {
 
 	public static void deleteUploadedJsons(Application a){
 		PreferenceManager pm = a.getPreferenceManager();
-		List<Measurement> measurements = Measurement.selectMeasurementsWithJson(a);
-		for (int i = 0; i < measurements.size(); i++) {
-			Measurement measurement = measurements.get(i);
-			//measurement.getUrlString will return null when the measurement is not a web_connectivity
-			a.getApiClient().getMeasurement(measurement.report_id, measurement.getUrlString()).enqueue(new GetMeasurementsCallback() {
+		Set<String> reportids = Measurement.getReportsUploaded(a);
+		for (String report_id : reportids) {
+			a.getApiClient().checkReportId(report_id).enqueue(new CheckReportIdCallback() {
 				@Override
-				public void onSuccess(ApiMeasurement.Result result) {
-					measurement.deleteEntryFile(a);
+				public void onSuccess(Boolean found) {
+					if (found)
+						Measurement.deleteMeasurementWithReportId(a, report_id);
 				}
 
 				@Override
@@ -252,6 +257,15 @@ public class Measurement extends BaseModel implements Serializable {
 			});
 		}
 		pm.setLastCalled();
+	}
+
+	private static void deleteMeasurementWithReportId(Application a, String report_id) {
+		Where<Measurement> msmQuery = Measurement.selectWithReportId(report_id);
+		List<Measurement> measurements = msmQuery.queryList();
+		for (int i = 0; i < measurements.size(); i++) {
+			Measurement measurement = measurements.get(i);
+			measurement.deleteEntryFile(a);
+		}
 	}
 
 	public static void deleteOldLogs(Application a){

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
@@ -259,12 +259,12 @@ public class Measurement extends BaseModel implements Serializable {
 		pm.setLastCalled();
 	}
 
-	private static void deleteMeasurementWithReportId(Application a, String report_id) {
+	public static void deleteMeasurementWithReportId(Context c, String report_id) {
 		Where<Measurement> msmQuery = Measurement.selectWithReportId(report_id);
 		List<Measurement> measurements = msmQuery.queryList();
 		for (int i = 0; i < measurements.size(); i++) {
 			Measurement measurement = measurements.get(i);
-			measurement.deleteEntryFile(a);
+			measurement.deleteEntryFile(c);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/1195

The algorithm would be:
- Query DB for measurement uploaded and with report_id
- Cycle them to get the ones with json file
- UNIQUE the report_id
- Call the api for every report_id
- If true 
    - query db to get all measurement with that report_id
    - Delete json
