### PR TITLE
Fix network count on test deletion

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -95,10 +95,7 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
         ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
         setHasOptionsMenu(true);
         getActivity().setTitle(R.string.TestResults_Overview_Title);
-        tests.setText(getString(R.string.d, SQLite.selectCountOf().from(Result.class).longValue()));
-        networks.setText(getString(R.string.d, SQLite.selectCountOf().from(Network.class).longValue()));
-        upload.setText(Result.readableFileSize(SQLite.select(Method.sum(Result_Table.data_usage_up)).from(Result.class).longValue()));
-        download.setText(Result.readableFileSize(SQLite.select(Method.sum(Result_Table.data_usage_down)).from(Result.class).longValue()));
+        reloadHeader();
         LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
         recycler.setLayoutManager(layoutManager);
         recycler.addItemDecoration(new DividerItemDecoration(getActivity(), layoutManager.getOrientation()));
@@ -115,6 +112,13 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
                                 .build().show(getChildFragmentManager(), null)
                 );
         return v;
+    }
+
+    public void reloadHeader() {
+        tests.setText(getString(R.string.d, SQLite.selectCountOf().from(Result.class).longValue()));
+        networks.setText(getString(R.string.d, SQLite.selectCountOf().from(Network.class).longValue()));
+        upload.setText(Result.readableFileSize(SQLite.select(Method.sum(Result_Table.data_usage_up)).from(Result.class).longValue()));
+        download.setText(Result.readableFileSize(SQLite.select(Method.sum(Result_Table.data_usage_down)).from(Result.class).longValue()));
     }
 
     @Override
@@ -241,6 +245,7 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
             else if (serializable.equals(R.id.delete))
                 Result.deleteAll(getActivity());
             queryList();
+            reloadHeader();
         }
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Network.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Network.java
@@ -81,7 +81,7 @@ public class Network extends BaseModel implements Serializable {
 	}
 
 	@Override public boolean delete() {
-		//Delete Network only if it's used in one or less Result
-		return SQLite.selectCountOf().from(Result.class).where(Result_Table.network_id.eq(id)).longValue() > 1 && super.delete();
+		//Delete Network only if it's used in no Result objects
+		return SQLite.selectCountOf().from(Result.class).where(Result_Table.network_id.eq(id)).longValue() == 0 && super.delete();
 	}
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Result.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Result.java
@@ -78,7 +78,7 @@ public class Result extends BaseModel implements Serializable {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-		Delete.tables(Measurement.class, Result.class);
+		Delete.tables(Measurement.class, Result.class, Network.class);
 	}
 
 	public List<Measurement> getMeasurements() {
@@ -209,5 +209,8 @@ public class Result extends BaseModel implements Serializable {
 			measurement.delete();
 		}
 		delete();
+		//Network object is deleted after the Result object to avoid constraint fail
+		if (this.network != null)
+			this.network.delete();
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/1240

## Proposed Changes

  - Deleting Network table when deleting all tests
  - Preventing deletion of the network object if it's in use
  - Deleting the network object after the Result is deleted to avoid crash for SQL CONSTRAINTS
