### PR TITLE
Remove firebase_core

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,8 +81,7 @@ dependencies {
 	implementation 'androidx.appcompat:appcompat:1.1.0'
 
 	fullImplementation 'com.google.firebase:firebase-messaging:20.1.4'
-	fullImplementation 'com.google.firebase:firebase-core:17.3.0'
-
+	
 	annotationProcessor 'com.github.Raizlabs.DBFlow:dbflow-processor:4.2.4'
 	implementation 'com.github.Raizlabs.DBFlow:dbflow-core:4.2.4'
 	implementation 'com.github.Raizlabs.DBFlow:dbflow:4.2.4'


### PR DESCRIPTION
@sarathms spotted we were having `com.google.android.gms.ads` and `com.google.firebase.analitycs`
in the app even I never imported them. 
It turns out  they are part of `com.google.firebase:firebase-core` that is now deprecated and not needed:
https://firebase.google.com/support/release-notes/android 