### PR TITLE
Fix crash - null check

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MainActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MainActivity.java
@@ -125,6 +125,7 @@ public class MainActivity extends AbstractActivity implements ConfirmDialogFragm
 
     @Override
     public void onConfirmation(Serializable extra, int i) {
+        if (extra == null) return;
         if (extra.equals(MANUAL_UPLOAD_DIALOG))
             getPreferenceManager().setManualUploadResults(i == DialogInterface.BUTTON_POSITIVE);
         else if (extra.equals(ANALYTICS_DIALOG))


### PR DESCRIPTION
Fixes `java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Object.equals(java.lang.Object)' on a null object reference`
