### PR TITLE
feat(countly): make exceptions more informative

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
@@ -68,6 +68,7 @@ public class TestAsyncTask<ACT extends AbstractActivity> extends AsyncTask<Abstr
 					catch (Exception e) {
 						e.printStackTrace();
 						ExceptionManager.logException(e);
+						// FALLTHROUGH
 					}
 					Response<UrlList> response = act.getOrchestraClient().getUrls(probeCC, act.getPreferenceManager().getEnabledCategory()).execute();
 					if (response.isSuccessful() && response.body() != null && response.body().results != null) {

--- a/engine/src/main/java/org/openobservatory/engine/Engine.java
+++ b/engine/src/main/java/org/openobservatory/engine/Engine.java
@@ -15,19 +15,13 @@ public final class Engine {
     }
 
     /** startExperimentTask starts the experiment described by the provided settings. */
-    public static OONIMKTask startExperimentTask(OONIMKTaskConfig settings) throws OONIException {
-        try {
-            return new PEMKTask(
-                    oonimkall.Oonimkall.startTask(settings.serialization())
-            );
-        } catch (Exception exc) {
-            throw new OONIException("cannot start OONI Probe Engine task", exc);
-        }
+    public static OONIMKTask startExperimentTask(OONIMKTaskConfig settings) throws Exception {
+        return new PEMKTask(oonimkall.Oonimkall.startTask(settings.serialization()));
     }
 
     /** resolveProbeCC returns the probeCC. */
     public static String resolveProbeCC(Context ctx, String softwareName,
-                                        String softwareVersion, long timeout) throws OONIException {
+                                        String softwareVersion, long timeout) throws Exception {
         OONISession session = newSession(Engine.getDefaultSessionConfig(
                 ctx, softwareName, softwareVersion, new LoggerNull()
         ));
@@ -40,7 +34,7 @@ public final class Engine {
     }
 
     /** newSession returns a new OONISession instance. */
-    public static OONISession newSession(OONISessionConfig config) throws OONIException {
+    public static OONISession newSession(OONISessionConfig config) throws Exception {
         return new PESession(config);
     }
 
@@ -48,20 +42,16 @@ public final class Engine {
     public static OONISessionConfig getDefaultSessionConfig(Context ctx,
                                                             String softwareName,
                                                             String softwareVersion,
-                                                            OONILogger logger) throws OONIException {
-        try {
-            OONISessionConfig config = new OONISessionConfig();
-            config.logger = new LoggerComposed(logger, new LoggerAndroid());
-            config.softwareName = softwareName;
-            config.softwareVersion = softwareVersion;
-            config.verbose = false;
-            config.assetsDir = Engine.getAssetsDir(ctx);
-            config.stateDir = Engine.getStateDir(ctx);
-            config.tempDir = Engine.getTempDir(ctx);
-            return config;
-        } catch (java.io.IOException exc) {
-            throw new OONIException("getDefaultSessionConfig failed", exc);
-        }
+                                                            OONILogger logger) throws Exception {
+        OONISessionConfig config = new OONISessionConfig();
+        config.logger = new LoggerComposed(logger, new LoggerAndroid());
+        config.softwareName = softwareName;
+        config.softwareVersion = softwareVersion;
+        config.verbose = false;
+        config.assetsDir = Engine.getAssetsDir(ctx);
+        config.stateDir = Engine.getStateDir(ctx);
+        config.tempDir = Engine.getTempDir(ctx);
+        return config;
     }
 
     /**

--- a/engine/src/main/java/org/openobservatory/engine/OONIException.java
+++ b/engine/src/main/java/org/openobservatory/engine/OONIException.java
@@ -1,8 +1,0 @@
-package org.openobservatory.engine;
-
-/** OONIException is the exception thrown by the this package. */
-public final class OONIException extends Exception {
-    public OONIException(String message, Throwable exc) {
-        super(message, exc);
-    }
-}

--- a/engine/src/main/java/org/openobservatory/engine/OONISession.java
+++ b/engine/src/main/java/org/openobservatory/engine/OONISession.java
@@ -8,10 +8,10 @@ package org.openobservatory.engine;
  */
 public interface OONISession {
     /** geolocate returns the probe geolocation. */
-    OONIGeolocateResults geolocate(OONIContext ctx) throws OONIException;
+    OONIGeolocateResults geolocate(OONIContext ctx) throws Exception;
 
     /** maybeUpdateResources updates resources if needed. */
-    void maybeUpdateResources(OONIContext ctx) throws OONIException;
+    void maybeUpdateResources(OONIContext ctx) throws Exception;
 
     /** newContext creates a new OONIContext instance. */
     OONIContext newContext();
@@ -24,5 +24,5 @@ public interface OONISession {
     OONIContext newContextWithTimeout(long timeout);
 
     /** submit submits a measurement and returns the submission results. */
-    OONISubmitResults submit(OONIContext ctx, String measurement) throws OONIException;
+    OONISubmitResults submit(OONIContext ctx, String measurement) throws Exception;
 }

--- a/engine/src/main/java/org/openobservatory/engine/PESession.java
+++ b/engine/src/main/java/org/openobservatory/engine/PESession.java
@@ -6,28 +6,16 @@ import oonimkall.Session;
 final class PESession implements OONISession {
     private Session session;
 
-    public PESession(OONISessionConfig config) throws OONIException {
-        try {
-            session = Oonimkall.newSession(config.toOonimkallSessionConfig());
-        } catch (Exception exc) {
-            throw new OONIException("Oonimkall.newSession failed", exc);
-        }
+    public PESession(OONISessionConfig config) throws Exception {
+        session = Oonimkall.newSession(config.toOonimkallSessionConfig());
     }
 
-    public OONIGeolocateResults geolocate(OONIContext ctx) throws OONIException {
-        try {
-            return new OONIGeolocateResults(session.geolocate(ctx.ctx));
-        } catch (Exception exc) {
-            throw new OONIException("session.geolocate failed", exc);
-        }
+    public OONIGeolocateResults geolocate(OONIContext ctx) throws Exception {
+        return new OONIGeolocateResults(session.geolocate(ctx.ctx));
     }
 
-    public void maybeUpdateResources(OONIContext ctx) throws OONIException {
-        try {
-            session.maybeUpdateResources(ctx.ctx);
-        } catch (Exception exc) {
-            throw new OONIException("session.maybeUpdateResources failed", exc);
-        }
+    public void maybeUpdateResources(OONIContext ctx) throws Exception {
+        session.maybeUpdateResources(ctx.ctx);
     }
 
     public OONIContext newContext() {
@@ -38,11 +26,7 @@ final class PESession implements OONISession {
         return new OONIContext(session.newContextWithTimeout(timeout));
     }
 
-    public OONISubmitResults submit(OONIContext ctx, String measurement) throws OONIException {
-        try {
-            return new OONISubmitResults(session.submit(ctx.ctx, measurement));
-        } catch (Exception exc) {
-            throw new OONIException("", exc);
-        }
+    public OONISubmitResults submit(OONIContext ctx, String measurement) throws Exception {
+        return new OONISubmitResults(session.submit(ctx.ctx, measurement));
     }
 }


### PR DESCRIPTION
I've been playing around with countly recently to ensure that the
code is such that exceptions that are trapped by countly are meaningful
enough to us to understand what is going on.

This investigation led me to understand that my original by the book
approach of teaching engine to throw OONIException, as opposed to just
Exception, was probably wrong here.

We're throwing Exception because Go is throwing Exception. Go cannot
do anything much smarter than that here.

By rewrapping the Exception, we're loosing context. We don't see the
cause of error directly in the first line, but further down below such
that we need to click through a specific error to have more info.

What's even more concerning is that countly truncates the stack trace
and the juicy information is dangerously near the bottom. So, it is
a simple refactoring to remove OONIException and it's also simple if
we wanna reintroduce it later. For now let's remove it, since it's
quite clear it may be potentially damaging in the name of purity.

With this diff, my investigation on what could be done to make countly
more actionable is probably complete. The original tracking issue for
this investigation is https://github.com/ooni/probe-engine/issues/1001.

There is also a registered follow-up action that can be performed later
and concerns making the error returned by probe services discovery
even more actionable https://github.com/ooni/probe-engine/issues/1049.

Fixes # <issue>

## Proposed Changes

  -
  -
  -
