### PR TITLE
fix test summary formatting for blocked riseupvpn gateways

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/model/jsonresult/TestKeys.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/jsonresult/TestKeys.java
@@ -194,10 +194,13 @@ public class TestKeys {
 					blockedConnection++;
 				}
 			}
-			return context.getResources().getQuantityString(R.plurals.TestResults_Overview_Circumvention_RiseupVPN_Blocked, blockedConnection);
-		} else {
-			return context.getString(R.string.TestResults_Details_Circumvention_RiseupVPN_Reachable_Okay);
+			if (blockedConnection == 0) {
+				return context.getString(R.string.TestResults_Details_Circumvention_RiseupVPN_Reachable_Okay);
+			}
+			return context.getResources().getQuantityString(R.plurals.TestResults_Overview_Circumvention_RiseupVPN_Blocked, blockedConnection, String.valueOf(blockedConnection));
 		}
+
+		return context.getString(R.string.TestResults_Details_Circumvention_RiseupVPN_Reachable_Okay);
 	}
 
 	public Boolean isNdt7() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/RiseupVPN.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/RiseupVPN.java
@@ -27,6 +27,6 @@ public class RiseupVPN extends AbstractTest {
 
     @Override public void onEntry(Context c, PreferenceManager pm, @NonNull JsonResult json, Measurement measurement) {
         super.onEntry(c, pm, json, measurement);
-        measurement.is_anomaly = json.test_keys.api_failure != null && json.test_keys.ca_cert_status && json.test_keys.failing_gateways == null;
+        measurement.is_anomaly = !json.test_keys.ca_cert_status || json.test_keys.api_failure != null || json.test_keys.failing_gateways != null;
     }
 }


### PR DESCRIPTION
No github issue assigned to the PR

## Proposed Changes

  - currently test summaries are shown incorrectly: instead of the number of blocked gateways or bridged connections the user sees "$1%s blocked" 
  - this PR fixes it:
  
![riseupvpnstats](https://user-images.githubusercontent.com/2614900/107888639-ef00d800-6f0d-11eb-856a-3d591b826da5.png)

Also the condition under which an anomaly was shown was wrong. The second commit fixes that by using a strict rule that riseupvpn is already considered as blocked if one gateway fails. 

In a subsequent step I would like to implement in probe-cli (probe-engine) 2 test result fields that indicate the overall numbers of tested openvpn and obfs4 gateways. Having that would allow us in the client to consider RiseupVPN blocked less strictly by assuming that if at least one working openvpn port has been reached, openvpn is not blocked and if at least one obfs4 port has been reached obfs4 is not blocked. It will reduce the number of false positives dramtically. I'll create for that proposal a separate issue (https://github.com/ooni/probe/issues/1354). 
