### PR TITLE
fix app crash when opening MeasurementDetailActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,9 +91,10 @@ dependencies {
 	implementation 'com.github.Raizlabs.DBFlow:dbflow-core:4.2.4'
 	implementation 'com.github.Raizlabs.DBFlow:dbflow:4.2.4'
 
-	implementation 'com.squareup.retrofit2:retrofit:2.6.0'
-	implementation 'com.squareup.retrofit2:converter-gson:2.6.0'
-	implementation 'com.squareup.okhttp3:logging-interceptor:4.0.1'
+	implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+	implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+	implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
+
 
 	implementation 'com.jakewharton:butterknife:10.2.3'
 	annotationProcessor 'com.jakewharton:butterknife-compiler:10.2.3'


### PR DESCRIPTION


Fixes https://github.com/ooni/probe/issues/1442

## Proposed Changes

  - updates retrofit dependencies
  - logging-interceptor was not needed to update to fix the crash, but was outdated, too.  In order to avoid any backward compatibility issues that cannot be seen on the first glance I updated the logging-interceptor, too


