### PR TITLE
adaptions for riseupvpn measurement v 0.2.0

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/model/jsonresult/TestKeys.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/jsonresult/TestKeys.java
@@ -7,6 +7,7 @@ import com.google.gson.annotations.SerializedName;
 import org.openobservatory.ooniprobe.R;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Locale;
 
 public class TestKeys {
@@ -85,6 +86,8 @@ public class TestKeys {
 	public Boolean ca_cert_status;
 	@SerializedName("failing_gateways")
 	public GatewayConnection[] failing_gateways;
+	@SerializedName("transport_status")
+	public HashMap<String, String> transport_status;
 
 	private static String setFractionalDigits(double value) {
 		return String.format(Locale.getDefault(), value < 10 ? "%.2f" : "%.1f", value);

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/RiseupVPN.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/RiseupVPN.java
@@ -27,6 +27,8 @@ public class RiseupVPN extends AbstractTest {
 
     @Override public void onEntry(Context c, PreferenceManager pm, @NonNull JsonResult json, Measurement measurement) {
         super.onEntry(c, pm, json, measurement);
-        measurement.is_anomaly = !json.test_keys.ca_cert_status || json.test_keys.api_failure != null || json.test_keys.failing_gateways != null;
+        boolean isTransportBlocked = json.test_keys.transport_status.getOrDefault("openvpn", "ok").equals("blocked") ||
+                json.test_keys.transport_status.getOrDefault("obfs4", "ok").equals("blocked");
+        measurement.is_anomaly = !json.test_keys.ca_cert_status || json.test_keys.api_failure != null || isTransportBlocked;
     }
 }


### PR DESCRIPTION
part of https://github.com/ooni/probe/issues/1354

## Proposed Changes

  - OONI Probe Android considers a measurement as anomaly if a all gateways supporting a transport are not working (before: if a single gateway fails)
  - the change is implemented with the intention to reduce false positives if one gateway is not working for whatever reason. In reality RiseupVPN users will fallback to other gateways and might be able to connect though those.

