### PR TITLE
Dependency injection configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,10 @@ dependencies {
 	fullImplementation 'ly.count.android:sdk:20.11.1'
 	fullImplementation 'io.sentry:sentry-android:4.0.0'
 
+// Dependency Injection
+	implementation 'com.google.dagger:dagger:2.35'
+	annotationProcessor 'com.google.dagger:dagger-compiler:2.35'
+
 // Testing
 	// Unit Testing
 	testImplementation 'junit:junit:4.13.2'
@@ -129,6 +133,7 @@ dependencies {
 	testImplementation 'androidx.test:rules:1.3.0'
 	testImplementation 'org.mockito:mockito-core:3.9.0'
 	testImplementation 'org.robolectric:robolectric:4.5.1'
+	testAnnotationProcessor "com.google.dagger:dagger-compiler:2.35"
 
 	// Instrumentation Testing
 	androidTestImplementation 'tools.fastlane:screengrab:2.0.0'

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -8,96 +8,64 @@ import androidx.lifecycle.OnLifecycleEvent;
 import androidx.lifecycle.ProcessLifecycleOwner;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.raizlabs.android.dbflow.config.FlowLog;
 import com.raizlabs.android.dbflow.config.FlowManager;
 
 import org.openobservatory.ooniprobe.BuildConfig;
 import org.openobservatory.ooniprobe.client.OONIAPIClient;
 import org.openobservatory.ooniprobe.common.service.RunTestService;
+import org.openobservatory.ooniprobe.di.AppComponent;
+import org.openobservatory.ooniprobe.di.ApplicationModule;
+import org.openobservatory.ooniprobe.di.DaggerAppComponent;
 import org.openobservatory.ooniprobe.model.database.Measurement;
-import org.openobservatory.ooniprobe.model.jsonresult.TestKeys;
 
-import java.io.IOException;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
 
-import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.logging.HttpLoggingInterceptor;
-import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
 
 
 public class Application extends android.app.Application {
-	private PreferenceManager preferenceManager;
-	private Gson gson;
-	private OkHttpClient okHttpClient;
-	private OONIAPIClient apiClient;
+	@Inject PreferenceManager _preferenceManager;
+	@Inject Gson _gson;
+	@Inject OkHttpClient _okHttpClient;
+	@Inject OONIAPIClient _apiClient;
+
+	protected AppComponent component;
 
 	@Override public void onCreate() {
 		super.onCreate();
+		component = buildDagger();
+		component.inject(this);
+
 		FlowManager.init(this);
-		preferenceManager = new PreferenceManager(this);
 		if (BuildConfig.DEBUG)
 			FlowLog.setMinimumLoggingLevel(FlowLog.Level.V);
 		AppLifecycleObserver appLifecycleObserver = new AppLifecycleObserver();
 		ProcessLifecycleOwner.get().getLifecycle().addObserver(appLifecycleObserver);
-		gson = new GsonBuilder().registerTypeAdapter(Date.class, new DateAdapter()).registerTypeAdapter(TestKeys.Tampering.class, new TamperingJsonDeserializer()).create();
-		if (preferenceManager.canCallDeleteJson())
+		if (_preferenceManager.canCallDeleteJson())
 			Measurement.deleteUploadedJsons(this);
 		Measurement.deleteOldLogs(this);
 		ThirdPartyServices.reloadConsents(this);
 	}
 
-	public OkHttpClient getOkHttpClient() {
-		if (okHttpClient == null) {
-			HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
-			logging.level(BuildConfig.DEBUG ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.BASIC);
-			okHttpClient = new OkHttpClient.Builder()
-					.connectTimeout(30, TimeUnit.SECONDS)
-					.readTimeout(30, TimeUnit.SECONDS)
-					.writeTimeout(30, TimeUnit.SECONDS)
-					.retryOnConnectionFailure(false)
-					.addInterceptor(logging)
-					.addInterceptor(new Interceptor() {
-						@Override
-						public Response intercept(Chain chain) throws IOException {
-							Request request = chain.request().newBuilder()
-									.addHeader("User-Agent", "ooniprobe-android/" + BuildConfig.VERSION_NAME)
-									.addHeader("Connection", "Close")
-									.build();
-							return chain.proceed(request);
-						}
-					})
-                    .build();
-		}
-		return okHttpClient;
+	protected AppComponent buildDagger() {
+		return DaggerAppComponent.builder().applicationModule(new ApplicationModule(this)).build();
 	}
 
-	public OONIAPIClient getApiClientWithUrl(String url) {
-		if (apiClient == null) {
-			apiClient = new Retrofit.Builder()
-					.baseUrl(url)
-					.addConverterFactory(GsonConverterFactory.create())
-					.client(getOkHttpClient())
-					.build().create(OONIAPIClient.class);
-		}
-		return apiClient;
+	public OkHttpClient getOkHttpClient() {
+		return _okHttpClient;
 	}
 
 	public OONIAPIClient getApiClient() {
-		return getApiClientWithUrl(BuildConfig.OONI_API_BASE_URL);
+		return _apiClient;
 	}
 
 	public PreferenceManager getPreferenceManager() {
-		return preferenceManager;
+		return _preferenceManager;
 	}
 
 	public Gson getGson() {
-		return gson;
+		return _gson;
 	}
 
 	public boolean isTestRunning() {
@@ -121,12 +89,13 @@ public class Application extends android.app.Application {
 		}
 		return false;
 	}
+
 	//from https://medium.com/mindorks/detecting-when-an-android-app-is-in-foreground-or-background-7a1ff49812d7
 	public class AppLifecycleObserver implements LifecycleObserver {
 
 		@OnLifecycleEvent(Lifecycle.Event.ON_START)
 		public void onEnterForeground() {
-			preferenceManager.incrementAppOpenCount();
+			_preferenceManager.incrementAppOpenCount();
 		}
 
 		@OnLifecycleEvent(Lifecycle.Event.ON_STOP)

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/DateAdapter.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/DateAdapter.java
@@ -11,7 +11,7 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.Date;
 
-class DateAdapter extends TypeAdapter<Date> {
+public class DateAdapter extends TypeAdapter<Date> {
 	@Override public void write(JsonWriter out, Date value) throws IOException {
 		if (value == null) {
 			out.nullValue();

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
@@ -15,6 +15,10 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Locale;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
 public class PreferenceManager {
 	static final String GEO_VER = "geo_ver";
 	public static final Integer MAX_RUNTIME_DISABLED = -1;
@@ -33,7 +37,7 @@ public class PreferenceManager {
 	private final SharedPreferences sp;
 	private final Resources r;
 
-	PreferenceManager(Context context) {
+	@Inject PreferenceManager(Context context) {
 		androidx.preference.PreferenceManager.setDefaultValues(context, R.xml.preferences_global, true);
 		sp = androidx.preference.PreferenceManager.getDefaultSharedPreferences(context);
 		r = context.getResources();

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/TamperingJsonDeserializer.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/TamperingJsonDeserializer.java
@@ -10,7 +10,7 @@ import org.openobservatory.ooniprobe.model.jsonresult.TestKeys;
 
 import java.lang.reflect.Type;
 
-class TamperingJsonDeserializer implements JsonDeserializer<TestKeys.Tampering> {
+public class TamperingJsonDeserializer implements JsonDeserializer<TestKeys.Tampering> {
 	@Override public TestKeys.Tampering deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
 		if (json.isJsonPrimitive() && json.getAsJsonPrimitive().isBoolean())
 			return new TestKeys.Tampering(json.getAsJsonPrimitive().getAsBoolean());

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/ActivityComponent.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/ActivityComponent.java
@@ -1,0 +1,10 @@
+package org.openobservatory.ooniprobe.di;
+
+
+import org.openobservatory.ooniprobe.di.annotations.PerActivity;
+
+import dagger.Subcomponent;
+
+@PerActivity
+@Subcomponent()
+public interface ActivityComponent { }

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/AppComponent.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/AppComponent.java
@@ -1,0 +1,19 @@
+package org.openobservatory.ooniprobe.di;
+
+import org.openobservatory.ooniprobe.common.Application;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+
+@Singleton
+@Component(modules = {
+        ApplicationModule.class
+})
+public interface AppComponent {
+
+    ActivityComponent activityComponent();
+    ServiceComponent serviceComponent();
+    void inject(Application app);
+
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/ApplicationModule.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/ApplicationModule.java
@@ -1,0 +1,107 @@
+package org.openobservatory.ooniprobe.di;
+
+import android.content.Context;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.openobservatory.ooniprobe.BuildConfig;
+import org.openobservatory.ooniprobe.client.OONIAPIClient;
+import org.openobservatory.ooniprobe.common.DateAdapter;
+import org.openobservatory.ooniprobe.common.TamperingJsonDeserializer;
+import org.openobservatory.ooniprobe.di.annotations.ApiUrl;
+import org.openobservatory.ooniprobe.di.annotations.HeaderInterceptor;
+import org.openobservatory.ooniprobe.model.jsonresult.TestKeys;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+@Module
+public class ApplicationModule {
+
+    android.app.Application application;
+
+    public ApplicationModule(android.app.Application application) {
+        this.application = application;
+    }
+
+    @Provides
+    Context provideAppContext() {
+        return application;
+    }
+
+    @Provides
+    @Singleton
+    Gson provideGson() {
+        return new GsonBuilder()
+                .registerTypeAdapter(Date.class, new DateAdapter())
+                .registerTypeAdapter(TestKeys.Tampering.class, new TamperingJsonDeserializer())
+                .create();
+    }
+
+    @Provides
+    @Singleton
+    HttpLoggingInterceptor provideLoggingInterceptor() {
+        return new HttpLoggingInterceptor();
+    }
+
+    @Provides
+    @Singleton
+    @HeaderInterceptor
+    Interceptor provideHeaderInterceptor() {
+        return chain -> {
+            Request request = chain.request().newBuilder()
+                    .addHeader("User-Agent", "ooniprobe-android/" + BuildConfig.VERSION_NAME)
+                    .addHeader("Connection", "Close")
+                    .build();
+            return chain.proceed(request);
+        };
+    }
+
+    @Provides
+    @Singleton
+    OkHttpClient provideOkHttpClient(HttpLoggingInterceptor logging, @HeaderInterceptor Interceptor headerInterceptor) {
+        logging.level(BuildConfig.DEBUG ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.BASIC);
+        return new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(false)
+                .addInterceptor(logging)
+                .addInterceptor(headerInterceptor)
+                .build();
+    }
+
+    protected String getApiUrl() {
+        return BuildConfig.OONI_API_BASE_URL;
+    }
+
+    @Provides
+    @ApiUrl
+    protected String provideApiUrl() {
+        return getApiUrl();
+    }
+
+    @Provides
+    @Singleton
+    protected OONIAPIClient provideApiClient(OkHttpClient client, @ApiUrl String url) {
+        return new Retrofit.Builder()
+                .baseUrl(url)
+                .addConverterFactory(GsonConverterFactory.create())
+                .client(client)
+                .build()
+                .create(OONIAPIClient.class);
+    }
+
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/ServiceComponent.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/ServiceComponent.java
@@ -1,0 +1,9 @@
+package org.openobservatory.ooniprobe.di;
+
+import org.openobservatory.ooniprobe.di.annotations.PerService;
+
+import dagger.Subcomponent;
+
+@PerService
+@Subcomponent()
+public interface ServiceComponent { }

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/annotations/ApiUrl.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/annotations/ApiUrl.java
@@ -1,0 +1,3 @@
+package org.openobservatory.ooniprobe.di.annotations;
+
+public @interface ApiUrl { }

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/annotations/HeaderInterceptor.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/annotations/HeaderInterceptor.java
@@ -1,0 +1,3 @@
+package org.openobservatory.ooniprobe.di.annotations;
+
+public @interface HeaderInterceptor { }

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/annotations/PerActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/annotations/PerActivity.java
@@ -1,0 +1,10 @@
+package org.openobservatory.ooniprobe.di.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PerActivity { }

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/annotations/PerService.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/annotations/PerService.java
@@ -1,0 +1,10 @@
+package org.openobservatory.ooniprobe.di.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PerService { }

--- a/app/src/test/java/org/openobservatory/ooniprobe/RobolectricAbstractTest.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/RobolectricAbstractTest.java
@@ -10,8 +10,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.openobservatory.ooniprobe.common.Application;
+import org.openobservatory.ooniprobe.di.TestApplication;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+@Config(application = TestApplication.class)
 @RunWith(RobolectricTestRunner.class)
 public abstract class RobolectricAbstractTest {
     protected Context c;

--- a/app/src/test/java/org/openobservatory/ooniprobe/client/OONIAPIClientTest.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/client/OONIAPIClientTest.java
@@ -5,14 +5,12 @@ import com.raizlabs.android.dbflow.sql.language.Delete;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.openobservatory.ooniprobe.RobolectricAbstractTest;
 import org.openobservatory.ooniprobe.client.callback.CheckReportIdCallback;
 import org.openobservatory.ooniprobe.client.callback.GetMeasurementJsonCallback;
 import org.openobservatory.ooniprobe.client.callback.GetMeasurementsCallback;
 import org.openobservatory.ooniprobe.model.api.ApiMeasurement;
 import org.openobservatory.ooniprobe.model.database.Measurement;
-import org.robolectric.RobolectricTestRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +30,7 @@ public class OONIAPIClientTest extends RobolectricAbstractTest {
     @Test
     public void getMeasurementSuccess() {
         final CountDownLatch signal = new CountDownLatch(1);
-        a.getApiClientWithUrl(CLIENT_URL).getMeasurement(EXISTING_REPORT_ID, null).enqueue(new GetMeasurementsCallback() {
+        a.getApiClient().getMeasurement(EXISTING_REPORT_ID, null).enqueue(new GetMeasurementsCallback() {
             @Override
             public void onSuccess(ApiMeasurement.Result result) {
                 Assert.assertNotNull(result);
@@ -68,7 +66,7 @@ public class OONIAPIClientTest extends RobolectricAbstractTest {
     @Test
     public void getMeasurementError() {
         final CountDownLatch signal = new CountDownLatch(1);
-        a.getApiClientWithUrl(CLIENT_URL).getMeasurement(NONEXISTING_REPORT_ID, null).enqueue(new GetMeasurementsCallback() {
+        a.getApiClient().getMeasurement(NONEXISTING_REPORT_ID, null).enqueue(new GetMeasurementsCallback() {
             @Override
             public void onSuccess(ApiMeasurement.Result result) {
                 Assert.fail();
@@ -93,7 +91,7 @@ public class OONIAPIClientTest extends RobolectricAbstractTest {
         final CountDownLatch signal = new CountDownLatch(1);
         Delete.table(Measurement.class);
         addMeasurement(EXISTING_REPORT_ID, false);
-        a.getApiClientWithUrl(CLIENT_URL).checkReportId(EXISTING_REPORT_ID).enqueue(new CheckReportIdCallback() {
+        a.getApiClient().checkReportId(EXISTING_REPORT_ID).enqueue(new CheckReportIdCallback() {
             @Override
             public void onSuccess(Boolean found) {
                 Assert.assertTrue(found);

--- a/app/src/test/java/org/openobservatory/ooniprobe/common/ApplicationTest.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/common/ApplicationTest.java
@@ -4,6 +4,8 @@ import androidx.test.filters.SmallTest;
 
 import org.junit.Test;
 import org.openobservatory.ooniprobe.RobolectricAbstractTest;
+import org.openobservatory.ooniprobe.di.TestAppComponent;
+import org.openobservatory.ooniprobe.di.TestApplication;
 
 import static org.junit.Assert.assertTrue;
 
@@ -12,5 +14,15 @@ public class ApplicationTest extends RobolectricAbstractTest {
     @Test
     public void packageName() {
         assertTrue(a.getPackageName().startsWith("org.openobservatory.ooniprobe"));
+    }
+
+    @Test
+    public void testApp() {
+        assertTrue(a instanceof TestApplication);
+    }
+
+    @Test
+    public void component() {
+        assertTrue(a.component instanceof TestAppComponent);
     }
 }

--- a/app/src/test/java/org/openobservatory/ooniprobe/di/TestAppComponent.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/di/TestAppComponent.java
@@ -1,0 +1,13 @@
+package org.openobservatory.ooniprobe.di;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+
+@Singleton
+@Component(modules = {
+        TestAppModule.class
+})
+public interface TestAppComponent extends AppComponent {
+    void inject(TestApplication app);
+}

--- a/app/src/test/java/org/openobservatory/ooniprobe/di/TestAppModule.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/di/TestAppModule.java
@@ -1,0 +1,21 @@
+
+package org.openobservatory.ooniprobe.di;
+
+import android.app.Application;
+
+import dagger.Module;
+
+@Module
+public class TestAppModule extends ApplicationModule {
+
+    private static final String CLIENT_URL = "https://ams-pg.ooni.org";
+
+    public TestAppModule(Application application) {
+        super(application);
+    }
+
+    @Override
+    protected String getApiUrl() {
+        return CLIENT_URL;
+    }
+}

--- a/app/src/test/java/org/openobservatory/ooniprobe/di/TestApplication.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/di/TestApplication.java
@@ -1,0 +1,11 @@
+package org.openobservatory.ooniprobe.di;
+
+import org.openobservatory.ooniprobe.common.Application;
+
+public class TestApplication extends Application {
+
+    @Override
+    protected AppComponent buildDagger() {
+        return DaggerTestAppComponent.builder().testAppModule(new TestAppModule(this)).build();
+    }
+}


### PR DESCRIPTION
The following PR contains the base files and configuration to install the [Dagger](https://dagger.dev/) compile-time dependency injection framework.

The refactor to include DI in most class's would be huge, since we will be refactoring the [domain logic](https://github.com/ooni/probe/issues/1448) we decided to make those changes incremental for an easier review and safer update.

Small changes can be found already in the _Application.java_ and _PreferenceManager_ class's as well as in the unit test's.

For more information and the official documentation please consult: https://dagger.dev/dev-guide/