### PR TITLE
chore: use ooni/probe-cli v3.10.0-beta.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ https://bintray.com/measurement-kit/android/android-libs).
 Ensure you have Android Studio and Android SDK installed. Build `fullRelease` variant using Android Studio or this command line:
 
 ```
-./gradlew assembleFullRelease
+./gradlew assembleDevFullRelease
 ```
 
 ## Building the app for f-droid

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		maven { url "https://jitpack.io" }
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:4.1.3'
+		classpath 'com.android.tools.build:gradle:4.2.0'
 		classpath 'com.google.gms:google-services:4.3.5'
 	}
 }

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    implementation 'org.ooni:oonimkall:2021.04.29-120054'
+    implementation "org.ooni:oonimkall:2021.05.13-070256"
 }


### PR DESCRIPTION
See https://github.com/ooni/probe/issues/1468

While there upgrade the gradle plugin and correct the command
to run a build from command line using `./gradlew`.

Fixes # <issue>

## Proposed Changes

  -
  -
  -
