### PR TITLE
fix(RunTestService.java): pending intent should be IMMUTABLE

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/service/RunTestService.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/service/RunTestService.java
@@ -80,7 +80,12 @@ public class RunTestService extends Service {
         //This intent is used to manage the stop test button in the notification
         Intent broadcastIntent = new Intent();
         broadcastIntent.setAction(RunTestService.ACTION_INTERRUPT);
-        PendingIntent pIntent = PendingIntent.getBroadcast(this,1, broadcastIntent,PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pIntent;
+        if (android.os.Build.VERSION.SDK_INT >= 23) {
+            pIntent = PendingIntent.getBroadcast(this, 1, broadcastIntent, PendingIntent.FLAG_IMMUTABLE);
+        } else {
+            pIntent = PendingIntent.getBroadcast(this, 1, broadcastIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        }
         builder.addAction(0, getApplicationContext().getString(R.string.Notification_StopTest), pIntent);
         startForeground(NOTIFICATION_ID, builder.build());
         /*


### PR DESCRIPTION
* fix(RunTestService.java): pending intent should be IMMUTABLE

The app was crashing because the code did not specify the pending
intent as IMMUTABLE (as far as I understand the stacktrace).

Closes https://github.com/ooni/probe/issues/1897

(This is not my domain of expertise and I think this patch could
and should be better refactored so that we always use a single
factory to create all the intents with the correct flags.)

* fix(RunTestService.java): use factories to avoid repeating ourselves

This diff addresses my previous concern that I fixed the immediate
problem but did not proactively check the rest of the codebase.

Now, `git grep -i pendingintent.newactivity` and
`git grep -i pendingintent.getbroadcast` say that we
have correctly wrapped all the calls.