### PR TITLE
feat: allow one to build and test a oonimkall.aar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode
 *.iml
 .gradle
 local.properties

--- a/README.md
+++ b/README.md
@@ -40,16 +40,65 @@ Other supported platforms: [iOS](https://github.com/ooni/probe-ios),
 
 ## Developer information
 
-This application requires Android Studio. We use gradle and, as part of the
+This application requires Android Studio. We use Gradle and, as part of the
 initial gradle sync, Android studio will download all the required
 dependencies.
 
 The most important dependency is `oonimkall`. This dependency contains
 the network measurement engine. Its sources are at
-[ooni/probe-cli](https://github.com/ooni/probe-cli). We fetch it
-from [Maven central](https://search.maven.org/artifact/org.ooni/oonimkall).
+[ooni/probe-cli](https://github.com/ooni/probe-cli).
 
-(You may need to set the `ANDROID_SDK_ROOT` environment variable.)
+When using Gradle from the command line, you will need to set the
+`ANDROID_SDK_ROOT` environment variable to point to the directory in
+which you have installed the Android SDK.
+
+## Build variants
+
+We use the classic `debug` and `release` build types. We also
+implement the following flavours:
+
+- `stable`, `dev`, and `experimental` (dimension: `testing`);
+
+- `full` and `fdroid` (dimension: `license`).
+
+The `testing` dimension controls whether we're building a release
+or a more unstable version. We build releases using the `stable`
+flavour. The `dev` flavour builds the version of the app that should
+be released on the store as the beta channel. The `experimental`
+flavour, instead, allows a developer to build a one-off version of
+the app that uses a custom build of the `oonimkall` library.
+
+For `stable` and `dev`, we fetch `oonimkall` from the
+[Maven central](https://search.maven.org/artifact/org.ooni/oonimkall)
+repository. The `experimental` flavour, instead, requires you to
+put the `oonimkall.aar` you built inside `engine-experimental`.
+
+The `license` dimension controls which proprietary libraries to include
+into the build. The `full` flavour includes all such dependencies,
+while the `fdroid` flavour does not include any of them.
+
+The variant names are therefore:
+
+- `experimentalFullDebug`
+- `experimentalFullRelease`
+- `devFullDebug`
+- `devFullRelease`
+- `stableFullDebug`
+- `stableFullRelease`
+
+We additionally have `stableFdroidDebug` and `stableFdroidRelease`.
+
+All of this is controlled by [app/build.gradle](app/build.gradle).
+
+## Gradle modules
+
+- [app](app) contains the mobile app;
+- [engine](engine) contains wrappers for `oonimkall`, the
+measurement engine library;
+- [engine-experimental](engine-experimental) allows us
+to implement the `experimental` build flavour where you
+put the `oonimkall.aar` file you built inside `engine-experimental`
+rather than downloading it from Maven Central.
 
 ## Building an apk
 

--- a/engine-experimental/.gitignore
+++ b/engine-experimental/.gitignore
@@ -1,0 +1,1 @@
+/oonimkall.aar

--- a/engine-experimental/README.md
+++ b/engine-experimental/README.md
@@ -1,0 +1,5 @@
+# module: engine-experimental
+
+This directory contains a gradle module that allows you to drop
+a `oonimkall.aar` file you compiled from `ooni/probe-cli` and
+use it to build an experimental OONI app to install in your phone.

--- a/engine-experimental/build.gradle
+++ b/engine-experimental/build.gradle
@@ -1,0 +1,2 @@
+configurations.maybeCreate("default")
+artifacts.add("default", file('oonimkall.aar'))

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,0 +1,10 @@
+# module: engine
+
+This directory contains a Gradle module that wraps the
+`oonimkall.aar` measurement library produced by `ooni/probe-cli`.
+
+Depending on the configuration you're using, we'll download
+`oonimkall.aar` from Maven Central, or we're using a local
+file `oonimkall.aar` inside of the `../engine-experimental`
+Gradle module. See [build.gradle](build.gradle) for more details.
+

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -13,8 +13,28 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    flavorDimensions 'testing'
+    productFlavors {
+        stable {
+            dimension 'testing'
+        }
+        experimental {
+            dimension 'testing'
+        }
+        dev {
+            dimension 'testing'
+        }
+    }
 }
 
 dependencies {
-    implementation 'org.ooni:oonimkall:2021.11.23-142059'
+    // For the stable and dev app flavours we're using the library
+    // build published at Maven Central.
+    stableImplementation 'org.ooni:oonimkall:2021.11.23-142059'
+    devImplementation 'org.ooni:oonimkall:2021.11.23-142059'
+
+    // For the experimental flavour, you need to compile your own
+    // oonimkall.aar and put it into the ../engine-experimental dir
+    experimentalImplementation project(":engine-experimental")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ':app'
 include ':engine'
+include ':engine-experimental'


### PR DESCRIPTION
Say you have built an experimental `oonimkall.aar` artifact
from the `ooni/probe-cli` repo at whatever commit in whatever
branch. Say you want to test such an artifact against the
current `master` of the `ooni/probe-android` app.

How do you achieve that?

1. copy `oonimkall.aar` inside `./engine-experimental`;

2. `./gradlew assembleExperimentalFullRelease` (remember to
set `ANDROID_SDK_ROOT`);

3. locate the `apk` using `find` and then use `adb install` to
install such an APK on your phone.

I'm doing this work as part of https://github.com/ooni/probe/issues/1917
to facilitate quickly testing of `torsf` and co-developing together
the `probe-cli` and `probe-android` repositories.
