### PR TITLE
Changed background color for proxy indicator on various modes.

### DIFF
--- a/app/src/main/res/drawable/rounded_corner.xml
+++ b/app/src/main/res/drawable/rounded_corner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-<solid android:color="@color/color_gray4"/>
+<solid android:color="@color/color_gray0"/>
 
 <padding
 android:left="1dp"


### PR DESCRIPTION
Fixes # ooni/probe#1919

## Proposed Changes

  - Changed background color for proxy indicator on various modes.
  

| Light Mode  | Dark Mode |
| ------------- | ------------- |
| ![Screenshot_20220203_165721](https://user-images.githubusercontent.com/17911892/152379783-e87202e2-78eb-4c0d-8f1b-ec0961639f2c.png)  | ![Screenshot_20220203_165751](https://user-images.githubusercontent.com/17911892/152379763-97a5329b-cfa2-4862-ad14-5c41eda15c94.png)  |


