### PR TITLE
Do not display VPN warnings when data sharing is disabled

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/CustomWebsiteActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/CustomWebsiteActivity.java
@@ -63,7 +63,7 @@ public class CustomWebsiteActivity extends AbstractActivity implements ConfirmDi
             WebsitesSuite suite = new WebsitesSuite();
             suite.getTestList(preferenceManager)[0].setInputs(urls);
 
-            RunningActivity.runAsForegroundService(CustomWebsiteActivity.this, suite.asArray(), this::finish);
+            RunningActivity.runAsForegroundService(CustomWebsiteActivity.this, suite.asArray(), this::finish, preferenceManager);
             return true;
         });
         add();

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -242,7 +242,10 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
     }
 
     private void runAsyncTask() {
-        new ResubmitAsyncTask(this, pm.getProxyURL()).execute(null, measurement.id);
+        measurementsManager.syncMeasurements(this, () -> {
+            new ResubmitAsyncTask(this, pm.getProxyURL()).execute(null, measurement.id);
+            this.load();
+        }, this::load, null, measurement.id);
     }
 
     private void load() {
@@ -265,7 +268,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                 Intent share = new Intent(Intent.ACTION_SEND);
                 share.putExtra(Intent.EXTRA_TEXT, measurementsManager.getExplorerUrl(measurement));
                 share.setType("text/plain");
-                Intent shareIntent = Intent. createChooser(share, null);
+                Intent shareIntent = Intent.createChooser(share, null);
                 startActivity(shareIntent);
                 return true;
             default:

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OoniRunActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OoniRunActivity.java
@@ -150,7 +150,7 @@ public class OoniRunActivity extends AbstractActivity {
 		}
 		run.setOnClickListener(v -> {
 
-			RunningActivity.runAsForegroundService(OoniRunActivity.this, suite.asArray(),this::finish);
+			RunningActivity.runAsForegroundService(OoniRunActivity.this, suite.asArray(),this::finish, preferenceManager);
 
 		});
 	}

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
@@ -87,7 +87,7 @@ public class OverviewActivity extends AbstractActivity {
 	}
 
 	@OnClick(R.id.run) void onRunClick() {
-		RunningActivity.runAsForegroundService(this, testSuite.asArray(), this::bindTestService);
+		RunningActivity.runAsForegroundService(this, testSuite.asArray(), this::bindTestService, preferenceManager);
 	}
 
 	@OnClick(R.id.customUrl) void customUrlClick() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
@@ -26,6 +26,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
 import org.openobservatory.ooniprobe.R;
+import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ResubmitTask;
 import org.openobservatory.ooniprobe.domain.GetResults;
 import org.openobservatory.ooniprobe.domain.GetTestSuite;
@@ -81,6 +82,9 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
 
     @Inject
     GetResults getResults;
+
+    @Inject
+    PreferenceManager preferenceManager;
 
     public static Intent newIntent(Context context, int id) {
         return new Intent(context, ResultDetailActivity.class).putExtra(ID, id);
@@ -153,7 +157,7 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
     }
 
     private void reTestWebsites() {
-        RunningActivity.runAsForegroundService(this, getTestSuite.getFrom(result).asArray(),this::finish);
+        RunningActivity.runAsForegroundService(this, getTestSuite.getFrom(result).asArray(),this::finish, preferenceManager);
     }
 
     private void runAsyncTask() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
@@ -88,7 +88,8 @@ public class RunningActivity extends AbstractActivity implements ConfirmDialogFr
      */
     public static void runAsForegroundService(AbstractActivity context,
                                               ArrayList<AbstractSuite> testSuites,
-                                              OnTestServiceStartedListener onTestServiceStartedListener) {
+                                              OnTestServiceStartedListener onTestServiceStartedListener,
+                                              PreferenceManager _preferenceManager) {
         if (ReachabilityManager.getNetworkType(context).equals(ReachabilityManager.NO_INTERNET)) {
             new MessageDialogFragment.Builder()
                     .withTitle(context.getString(R.string.Modal_Error))
@@ -99,7 +100,7 @@ public class RunningActivity extends AbstractActivity implements ConfirmDialogFr
                     .withTitle(context.getString(R.string.Modal_Error))
                     .withMessage(context.getString(R.string.Modal_Error_TestAlreadyRunning))
                     .build().show(context.getSupportFragmentManager(), null);
-        } else if (ReachabilityManager.isVPNinUse(context)) {
+        } else if (ReachabilityManager.isVPNinUse(context) && _preferenceManager.isUploadResults()) {
             new AlertDialog.Builder(context, R.style.MaterialAlertDialogCustom)
                     .setTitle(context.getString(R.string.Modal_DisableVPN_Title))
                     .setMessage(context.getString(R.string.Modal_DisableVPN_Message))

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/FragmentComponent.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/FragmentComponent.java
@@ -1,6 +1,7 @@
 package org.openobservatory.ooniprobe.di;
 
 import org.openobservatory.ooniprobe.di.annotations.PerActivity;
+import org.openobservatory.ooniprobe.fragment.DashboardFragment;
 import org.openobservatory.ooniprobe.fragment.ProgressFragment;
 import org.openobservatory.ooniprobe.fragment.ResultListFragment;
 import org.openobservatory.ooniprobe.fragment.onboarding.Onboarding3Fragment;
@@ -11,6 +12,7 @@ import dagger.Subcomponent;
 @PerActivity
 @Subcomponent()
 public interface FragmentComponent {
+    void inject(DashboardFragment fragment);
     void inject(Onboarding3Fragment fragment);
     void inject(ResultListFragment fragment);
     void inject(ProgressFragment fragment);

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/MeasurementsManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/MeasurementsManager.java
@@ -1,19 +1,26 @@
 package org.openobservatory.ooniprobe.domain;
 
+import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
 
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.Lists;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
+import com.raizlabs.android.dbflow.sql.language.Where;
 
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.openobservatory.engine.OONIContext;
 import org.openobservatory.engine.OONISession;
 import org.openobservatory.engine.OONISubmitResults;
+import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.client.OONIAPIClient;
 import org.openobservatory.ooniprobe.client.callback.CheckReportIdCallback;
+import org.openobservatory.ooniprobe.common.Application;
 import org.openobservatory.ooniprobe.common.JsonPrinter;
+import org.openobservatory.ooniprobe.common.ReachabilityManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.domain.callback.DomainCallback;
 import org.openobservatory.ooniprobe.domain.callback.GetMeasurementsCallback;
@@ -24,6 +31,7 @@ import org.openobservatory.ooniprobe.model.database.Measurement_Table;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -109,6 +117,57 @@ public class MeasurementsManager {
         return jsonPrinter.prettyText(FileUtils.readFileToString(entryFile, StandardCharsets.UTF_8));
     }
 
+    public void syncMeasurements(Activity activity,
+                                 OnStartResubmission onStartResubmission,
+                                 OnCancelResubmission onCancelResubmission,
+                                 Integer... params) {
+
+        if (determineIfMeasurementsWereTakenOverVPN(params)) {
+            new AlertDialog.Builder(activity, R.style.MaterialAlertDialogCustom)
+                    .setTitle(activity.getString(R.string.Modal_UploadVPNResults_Title))
+                    .setMessage(activity.getString(R.string.Modal_UploadVPNResults_Message))
+                    .setNegativeButton(R.string.Modal_Cancel, (dialogInterface, i) -> {
+                        dialogInterface.dismiss();
+                        onCancelResubmission.onCancel();
+                    })
+                    .setPositiveButton(R.string.Modal_OK, (dialogInterface, i) -> {
+                        onStartResubmission.onResubmit();
+                    })
+                    .show();
+        } else {
+            onStartResubmission.onResubmit();
+        }
+    }
+
+    public boolean determineIfMeasurementsWereTakenOverVPN(Integer... params) {
+        if (params.length != 2)
+            throw new IllegalArgumentException("MKCollectorResubmitTask requires 2 nullable params: result_id, measurement_id");
+        Where<Measurement> msmQuery = Measurement.selectUploadable();
+        if (params[0] != null) {
+            msmQuery.and(Measurement_Table.result_id.eq(params[0]));
+        }
+        if (params[1] != null) {
+            msmQuery.and(Measurement_Table.id.eq(params[1]));
+        }
+        //Get a list of measurements with report file
+        List<Measurement> measurements = Measurement.withReport(context, msmQuery);
+
+        return Lists.transform(measurements, measurement -> {
+            try {
+                return ((Application) context.getApplicationContext()).getGson().fromJson(
+                        FileUtils.readFileToString(
+                                Measurement.getEntryFile(context, measurement.id, measurement.test_name),
+                                StandardCharsets.UTF_8
+                        ),
+                        Measurement.DataRoot.class
+                ).annotations.network_type;
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }).contains(ReachabilityManager.VPN);
+    }
+
     public void downloadReport(Measurement measurement, DomainCallback<String> callback) {
         //measurement.getUrlString will return null when the measurement is not a web_connectivity
         apiClient.getMeasurement(measurement.report_id, measurement.getUrlString()).enqueue(new GetMeasurementsCallback() {
@@ -165,5 +224,12 @@ public class MeasurementsManager {
 
     public long getTimeout(long length) {
         return length / 2000 + 10;
+    }
+
+    public interface OnStartResubmission {
+        void onResubmit();
+    }
+    public interface OnCancelResubmission {
+        void onCancel();
     }
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.java
@@ -19,9 +19,11 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.activity.AbstractActivity;
+import org.openobservatory.ooniprobe.activity.MainActivity;
 import org.openobservatory.ooniprobe.activity.OverviewActivity;
 import org.openobservatory.ooniprobe.activity.RunningActivity;
 import org.openobservatory.ooniprobe.common.Application;
+import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ReachabilityManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.item.TestsuiteItem;
@@ -30,6 +32,9 @@ import org.openobservatory.ooniprobe.test.TestAsyncTask;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
 
 import java.util.ArrayList;
+import java.util.Objects;
+
+import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -42,6 +47,9 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
     @BindView(R.id.run_all) TextView runAll;
 	@BindView(R.id.vpn) TextView vpn;
 
+	@Inject
+	PreferenceManager preferenceManager;
+
 	private ArrayList<TestsuiteItem> items;
 	private ArrayList<AbstractSuite> testSuites;
 	private HeterogeneousRecyclerAdapter<TestsuiteItem> adapter;
@@ -49,6 +57,7 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
 	@Nullable @Override public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
 		View v = inflater.inflate(R.layout.fragment_dashboard, container, false);
 		ButterKnife.bind(this, v);
+		((Application) getActivity().getApplication()).getFragmentComponent().inject(this);
 		((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
 		((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(null);
 		items = new ArrayList<>();
@@ -70,7 +79,8 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
 			items.add(new TestsuiteItem(testSuite, this));
 		setLastTest();
 		adapter.notifyTypesChanged();
-		if (ReachabilityManager.isVPNinUse(this.getContext()))
+		if (ReachabilityManager.isVPNinUse(this.getContext())
+				&& preferenceManager.isUploadResults())
 			vpn.setVisibility(View.VISIBLE);
 		else
 			vpn.setVisibility(View.GONE);
@@ -89,7 +99,7 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
 	}
 
     public void runAll() {
-        RunningActivity.runAsForegroundService((AbstractActivity) getActivity(), testSuites, this::onTestServiceStartedListener);
+        RunningActivity.runAsForegroundService((AbstractActivity) getActivity(), testSuites, this::onTestServiceStartedListener, preferenceManager);
     }
 
     private void onTestServiceStartedListener() {
@@ -108,7 +118,8 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
                 RunningActivity.runAsForegroundService(
                         (AbstractActivity) getActivity(),
                         testSuite.asArray(),
-                        this::onTestServiceStartedListener
+                        this::onTestServiceStartedListener,
+						preferenceManager
                 );
 				break;
 			default:

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -173,13 +173,18 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
         }
     }
 
-    @OnItemSelected(R.id.filterTests)
-    void queryList() {
+    private void load() {
         if (measurementsManager.hasUploadables()) {
             snackbar.show();
         } else {
             snackbar.dismiss();
         }
+    }
+
+
+    @OnItemSelected(R.id.filterTests)
+    void queryList() {
+        this.load();
 
         items.clear();
 
@@ -247,12 +252,13 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
     public void onConfirmation(Serializable serializable, int i) {
         if (serializable.equals(R.string.Modal_ResultsNotUploaded_Title)) {
             if (i == DialogInterface.BUTTON_POSITIVE) {
-                new ResubmitAsyncTask(this, pm.getProxyURL()).execute(null, null);
-            }
-            else if (i == DialogInterface.BUTTON_NEUTRAL) {
+                measurementsManager.syncMeasurements(getActivity(), () -> {
+                    new ResubmitAsyncTask(this, pm.getProxyURL()).execute(null, null);
+                    this.load();
+                }, this::load, null, null);
+            } else if (i == DialogInterface.BUTTON_NEUTRAL) {
                 startActivity(TextActivity.newIntent(getActivity(), TextActivity.TYPE_UPLOAD_LOG, (String) serializable));
-            }
-            else
+            } else
                 snackbar.show();
         } else if (i == DialogInterface.BUTTON_POSITIVE) {
             if (serializable instanceof Result)

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.activity.AbstractActivity;
 import org.openobservatory.ooniprobe.activity.RunningActivity;
+import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
@@ -19,11 +20,16 @@ import org.openobservatory.ooniprobe.test.test.AbstractTest;
 
 import java.util.Collections;
 
+import javax.inject.Inject;
+
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 
 public class FailedFragment extends Fragment {
 	private static final String MEASUREMENT = "measurement";
+
+	@Inject
+	PreferenceManager preferenceManager;
 
 	public static FailedFragment newInstance(Measurement measurement) {
 		Bundle args = new Bundle();
@@ -61,6 +67,6 @@ public class FailedFragment extends Fragment {
 						exception.printStackTrace();
 						ThirdPartyServices.logException(exception);
 					}
-				});
+				},preferenceManager);
 	}
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
@@ -330,4 +330,13 @@ public class Measurement extends BaseModel implements Serializable {
 		this.is_rerun = true;
 		this.save();
 	}
+
+	public class DataRoot {
+		public Annotations annotations;
+
+		public class Annotations {
+			public String network_type;
+		}
+	}
+
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">تم التحميل بنجاح</string>
   <string name="Modal_DisplayFailureLog">عرض سجل الإخفاق</string>
   <string name="Modal_EnableNotifications_Title">احصل.ي على تحديثات حول الرّقابة على الانترنت </string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">S\'ha pujat amb èxit</string>
   <string name="Modal_DisplayFailureLog">Mostra el registre d\'errors</string>
   <string name="Modal_EnableNotifications_Title">Obtingueu actualitzacions sobre la censura a Internet</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe kann nicht automatisch ohne Batterieoptimierung laufen. Möchtest du es noch einmal versuchen?</string>
   <string name="Modal_DisableVPN_Title">Bitte deaktiviere deine VPN-Verbindung.</string>
   <string name="Modal_DisableVPN_Message">Wenn du OONI Probe mit aktiviertem VPN ausführst, kann es sein, dass die Testergebnisse aus dem falschen Land stammen. Bitte deaktiviere deine VPN-Verbindung.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Hochladen war erfolgreich</string>
   <string name="Modal_DisplayFailureLog">Fehlerlog anzeigen</string>
   <string name="Modal_EnableNotifications_Title">Aktuelle Informationen zur Internetzensur</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Επιτυχές ανέβασμα</string>
   <string name="Modal_DisplayFailureLog">Προβολή αρχείου καταγραφής αποτυχιών</string>
   <string name="Modal_EnableNotifications_Title">Ειδοποιήσεις για λογοκρισία στο διαδίκτυο</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe no se puede ejecutar automáticamente sin optimización de batería. ¿Quieres intentarlo de nuevo?</string>
   <string name="Modal_DisableVPN_Title">Por favor deshabilita tu conexión VPN.</string>
   <string name="Modal_DisableVPN_Message">Si ejecutas OONI Probe con una VPN habilitada, los resultados de la prueba podrían aparecer como proviniendo desde el país incorrecto. Por favor deshabilita tu conexión VPN.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Subida exitosa</string>
   <string name="Modal_DisplayFailureLog">Mostrar registro de fallos</string>
   <string name="Modal_EnableNotifications_Title">Obtiene actualizaciones sobre censura en Internet</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe بدون بهینه‌سازی باتری قادر به اجرای خودکار نیست. آیا می‌خواهید دوباره تلاش کنید؟</string>
   <string name="Modal_DisableVPN_Title">لطفا اتصال VPN خود را غیرفعال کنید.</string>
   <string name="Modal_DisableVPN_Message">اگر OONI Probe را در حالی که متصل به VPN هستید اجرا کنید، نتایج ممکن است برای کشور اشتباهی نمایش داده شوند. لطفا اتصال VPN خود را غیرفعال کنید.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">بارگذاری با موفقیت انجام شد.</string>
   <string name="Modal_DisplayFailureLog">نمایش گزارش خرابی</string>
   <string name="Modal_EnableNotifications_Title">دریافت به‌روزرسانی سانسور اینترنت</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe ne peut pas fonctionner automatiquement sans optimisation de la pile. Voulez-vous réessayer ?</string>
   <string name="Modal_DisableVPN_Title">Veuillez désactiver votre connexion RPV.</string>
   <string name="Modal_DisableVPN_Message">Si vous exécutez OONI Probe alors qu’un RPV (réseau privé virtuel) est activé, les résultats des tests pourraient sembler provenir du mauvais pays. Veuillez désactiver votre connexion RPV.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Téléversement réussi</string>
   <string name="Modal_DisplayFailureLog">Afficher le journal des échecs</string>
   <string name="Modal_EnableNotifications_Title">Obtenez des mises à jour sur la censure d’Internet</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">अपलोड सफल रहा।</string>
   <string name="Modal_DisplayFailureLog">विफलता लॉग प्रदर्शित करें</string>
   <string name="Modal_EnableNotifications_Title">इंटरनेट सेंसरशिप पर नई जानकारी प्राप्त करें</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe tidak dapat berjalan dengan otomatis tanpa pengoptimalan baterai. Apakah Anda ingin mencoba lagi?</string>
   <string name="Modal_DisableVPN_Title">Mohon nonaktifkan koneksi VPN Anda.</string>
   <string name="Modal_DisableVPN_Message">Jika Anda menjalankan tes OONI Probe dengan VPN yang diaktifkan, hasil tes akan terlihat berasal dari negara yang salah. Mohon nonaktifkan koneksi VPN.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Unggahan berhasil</string>
   <string name="Modal_DisplayFailureLog">Tampilkan log kesalahan</string>
   <string name="Modal_EnableNotifications_Title">Dapatkan informasi terbaru mengenai penyensoran Internet</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe getur ekki keyrt á þess að rafhlöðunotkun sé bestuð. Viltu prófa aftur?</string>
   <string name="Modal_DisableVPN_Title">Gerðu VPN-tenginguna þína óvirka.</string>
   <string name="Modal_DisableVPN_Message">Ef þú keyrir OONI Probe með virku VPN, geta niðurstöður prófana litið út fyrir að koma frá röngu landi. Gerðu VPN-tenginguna þína óvirka.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Innsending tókst</string>
   <string name="Modal_DisplayFailureLog">Birta mistakaskrá</string>
   <string name="Modal_EnableNotifications_Title">Fáðu vísbendingar um ritskoðun internetsins</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Caricamento riuscito</string>
   <string name="Modal_DisplayFailureLog">Visualizza registro errori</string>
   <string name="Modal_EnableNotifications_Title">Ricevi aggiornamenti sulla censura di internet</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Succesvol geupload</string>
   <string name="Modal_DisplayFailureLog">Storingslogboek weergeven</string>
   <string name="Modal_EnableNotifications_Title">Ontvang updates over internetcensuur</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe não pode ser executado automaticamente sem a otimização da bateria. Você quer tentar novamente?</string>
   <string name="Modal_DisableVPN_Title">Por favor, desative sua conexão VPN.</string>
   <string name="Modal_DisableVPN_Message">Se você executar OONI Probe com uma VPN habilitada, os resultados do teste podem parecer que vêm do país errado. Por favor, desabilite sua conexão VPN.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Carregamento bem-sucedido</string>
   <string name="Modal_DisplayFailureLog">Exibir log de falhas</string>
   <string name="Modal_EnableNotifications_Title">Receba atualizações sobre censura na internet</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Încărcare realizată cu succes</string>
   <string name="Modal_DisplayFailureLog">Afișare jurnal de erori</string>
   <string name="Modal_EnableNotifications_Title">Get updates on internet censorship</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Загрузка успешно завершена</string>
   <string name="Modal_DisplayFailureLog">Показать список ошибок</string>
   <string name="Modal_EnableNotifications_Title">Получайте обновления об интернет-цензуре</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Nahrávanie prebehlo úspešne</string>
   <string name="Modal_DisplayFailureLog">Zobraziť denník zlyhaní</string>
   <string name="Modal_EnableNotifications_Title">Get updates on internet censorship</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Ngarkimi i sukseshëm</string>
   <string name="Modal_DisplayFailureLog">Display failure log</string>
   <string name="Modal_EnableNotifications_Title">Get updates on internet censorship</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Kupakia kumefanikiwa </string>
   <string name="Modal_DisplayFailureLog">Onyesha kumbukumbu ya kutofaulu</string>
   <string name="Modal_EnableNotifications_Title">Pata sasisho juu ya udhibiti wa mtandao</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">อัปโหลดสำเร็จ</string>
   <string name="Modal_DisplayFailureLog">แสดงปูมความล้มเหลว</string>
   <string name="Modal_EnableNotifications_Title">รับข่าวสารเกี่ยวกับการปิดกั้นอินเทอร์เน็ต</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe, pil iyileştirmesi olmadan otomatik olarak çalışamaz. Yeniden denemek ister misiniz?</string>
   <string name="Modal_DisableVPN_Title">Lütfen VPN bağlantınızı kapatın.</string>
   <string name="Modal_DisableVPN_Message">OONI Probe uygulamasını VPN açıkken çalıştırırsanız, sınama sonuçları yanlış ülkeden geliyormuş gibi görünebilir. Lütfen VPN bağlantınızı kapatın.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Yüklendi</string>
   <string name="Modal_DisplayFailureLog">Hata günlüğünü görüntüle</string>
   <string name="Modal_EnableNotifications_Title">İnternet sansürleri hakkında güncel bilgileri alın</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">如果没有优化电池，OONI无法自动运行。你想再试一次吗</string>
   <string name="Modal_DisableVPN_Title">请关闭您的VPN连接。</string>
   <string name="Modal_DisableVPN_Message">如果您在启用VPN的情况下运行OONI，测试结果可能看起来来自错误的国家。请关闭您的VPN连接。</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">上传成功</string>
   <string name="Modal_DisplayFailureLog">显示失败日志</string>
   <string name="Modal_EnableNotifications_Title">获取网络审查的动态</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">成功上傳</string>
   <string name="Modal_DisplayFailureLog">Display failure log</string>
   <string name="Modal_EnableNotifications_Title">取得最新網路審查動態</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,8 @@
   <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
   <string name="Modal_DisableVPN_Title">Please disable your VPN connection.</string>
   <string name="Modal_DisableVPN_Message">If you run OONI Probe with a VPN enabled, the test results may appear to come from the wrong country. Please disable your VPN connection.</string>
+  <string name="Modal_UploadVPNResults_Title">Some measurements were taken over VPN.</string>
+  <string name="Modal_UploadVPNResults_Message">If you upload measurements taken when VPN enabled, the test results may appear to come from the wrong country.</string>
   <string name="Toast_ResultsUploaded">Upload successful</string>
   <string name="Modal_DisplayFailureLog">Display failure log</string>
   <string name="Modal_EnableNotifications_Title">Get updates on internet censorship</string>


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2015

## Proposed Changes

  - Update service `RunningActivity` to only show modal when `VPN` and `upload_results` are enabled.
  - Show `VPN` warning modal if any measurement to be uploaded has `VPN` enabled in annotations. 
 
| Light Theme      | Dark Theme |
| ----------- | ----------- |
|    ![Screenshot_20220307_215236](https://user-images.githubusercontent.com/17911892/157116673-dcb8bea7-d16b-4318-8b48-a443884b67bd.png)   |     ![Screenshot_20220307_215207](https://user-images.githubusercontent.com/17911892/157116761-d0fab3c5-1c16-4102-b44a-b85571ce91d7.png)   |
|   ![Screenshot_20220307_215251](https://user-images.githubusercontent.com/17911892/157116940-31d80fbf-5cb9-4093-b52b-942aa0c4ff07.png) |   ![Screenshot_20220307_215326](https://user-images.githubusercontent.com/17911892/157117067-5057d37b-19d3-46f5-9411-935be61941c3.png) |
|  ![Screenshot_20220307_215433](https://user-images.githubusercontent.com/17911892/157117222-629360f2-cca4-448b-91ab-4f8f46b16fc2.png) | ![Screenshot_20220307_215459](https://user-images.githubusercontent.com/17911892/157117262-45ad45bc-7a75-419f-b11e-b097ea397b45.png) |
