### PR TITLE
fix background color in the experimental test group animation

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/ExperimentalSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/ExperimentalSuite.java
@@ -18,7 +18,7 @@ public class ExperimentalSuite extends AbstractSuite {
                 R.string.Dashboard_Experimental_Card_Description,
                 R.drawable.test_experimental,
                 R.drawable.test_experimental_24,
-                R.color.color_gray7,
+                R.color.color_gray7_1,
                 R.style.Theme_MaterialComponents_Light_DarkActionBar_App_NoActionBar_Experimental,
                 R.style.Theme_MaterialComponents_NoActionBar_App_Experimental,
                 R.string.Dashboard_Experimental_Overview_Paragraph,

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
 	<color name="color_gray5">#adb5bd</color>  <!-- failed measurement text -->
 	<color name="color_gray6">#868e96</color>  <!-- failed measurement tint -->
 	<color name="color_gray7">#495057</color>  <!-- text color and icon tint -->
+	<color name="color_gray7_1">#495057</color>  <!-- Experimental Suite -->
 	<color name="color_gray8">#343a40</color>  <!-- onboarding buttons -->
 	<color name="color_gray9">#212529</color>  <!-- used as light black -->
 	<color name="color_blue0">#e7f5ff</color>   <!-- not_used -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -99,7 +99,7 @@
 	</style>
 
 	<style name="Theme.MaterialComponents.Light.DarkActionBar.App.NoActionBar.Experimental">
-		<item name="colorPrimary">@color/color_gray7</item>
+		<item name="colorPrimary">@color/color_gray7_1</item>
 		<item name="colorPrimaryDark">@color/color_gray8</item>
 	</style>
 
@@ -149,7 +149,7 @@
 	</style>
 
 	<style name="Theme.MaterialComponents.NoActionBar.App.Experimental">
-		<item name="colorPrimary">@color/color_gray7</item>
+		<item name="colorPrimary">@color/color_gray7_1</item>
 		<item name="colorPrimaryDark">@color/color_gray8</item>
 		<item name="android:windowBackground">@color/color_gray7</item>
 	</style>


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2038

## Proposed Changes

  - Change the colour resource in light/dark mode

| Light | Dark | Light | Dark |
| ----------- | ----------- | ----------- | ----------- |
| ![Screenshot_20220321_142904](https://user-images.githubusercontent.com/17911892/159271487-fd65c41e-ab47-4cdb-8eec-cc717e213b6f.png)      | ![Screenshot_20220321_142841](https://user-images.githubusercontent.com/17911892/159271496-d861c642-b032-4786-85b6-ff5ba2a09950.png)  | ![Screenshot_20220321_142809](https://user-images.githubusercontent.com/17911892/159271502-774917a2-d79e-4fe2-8de3-10080a5b2f52.png) | ![Screenshot_20220321_142738](https://user-images.githubusercontent.com/17911892/159271511-1f95b915-f38d-4d85-9e60-e46892e0e0c3.png) |

