### PR TITLE
Improve communication of which websites are tested by OONI Probe

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/CustomWebsiteActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/CustomWebsiteActivity.java
@@ -147,7 +147,6 @@ public class CustomWebsiteActivity extends AbstractActivity implements ConfirmDi
                 CustomWebsiteActivity.this.scrollToBottom();
             }
 
-            binding.loadFromWebConnectivity.setVisibility(View.VISIBLE);
             binding.progressIndicator.setVisibility(View.INVISIBLE);
             binding.bottomBar.getMenu().findItem(R.id.runButton).setEnabled(true);
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/adapters/CustomWebsiteRecyclerViewAdapter.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/adapters/CustomWebsiteRecyclerViewAdapter.java
@@ -6,61 +6,44 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.common.collect.Lists;
 
 import org.openobservatory.ooniprobe.databinding.EdittextUrlBinding;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CustomWebsiteRecyclerViewAdapter extends RecyclerView.Adapter<CustomWebsiteRecyclerViewAdapter.ViewHolder> {
 
     private final List<String> mItems;
-
-    // BEGIN_INCLUDE(recyclerViewSampleViewHolder)
-
-    /**
-     * Provide a reference to the type of views that you are using (custom ViewHolder)
-     */
-    public static class ViewHolder extends RecyclerView.ViewHolder {
-        private final EdittextUrlBinding binding;
-//        private final TextView textView;
-
-        public ViewHolder(EdittextUrlBinding binding) {
-            super(binding.getRoot());
-            this.binding = binding;
-            binding.getRoot().setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-//                    Log.d(TAG, "Element " + getAdapterPosition() + " clicked.");
-                }
-            });
-//            textView = (TextView) v.findViewById(R.id.textView);
-        }
-
-//        public TextView getTextView() {
-//            return textView;
-//        }
-    }
+    private final List<Boolean> mVisibility;
+    private final ItemRemovedListener onItemRemoved;
 
     /**
      * Initialize the dataset of the Adapter.
-     *
-     * @param dataSet List<String> containing the data to populate views to be used by RecyclerView.
      */
-    public CustomWebsiteRecyclerViewAdapter(List<String> dataSet) {
-        mItems = dataSet;
+    public CustomWebsiteRecyclerViewAdapter(ItemRemovedListener onItemRemoved) {
+        mItems = new ArrayList<>();
+        mVisibility = new ArrayList<>();
+        this.onItemRemoved = onItemRemoved;
     }
 
     public void addAll(List<String> dataSet) {
         mItems.addAll(dataSet);
+        mVisibility.addAll(Lists.transform(dataSet, input -> Boolean.TRUE));
+        mVisibility.set(0, mItems.size() > 1);
     }
 
     public List<String> getItems() {
         return mItems;
     }
 
+    @NonNull
     @Override
-    public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup viewGroup, int viewType) {
         EdittextUrlBinding binding = EdittextUrlBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false);
         return new ViewHolder(binding);
     }
@@ -68,11 +51,20 @@ public class CustomWebsiteRecyclerViewAdapter extends RecyclerView.Adapter<Custo
     @Override
     public void onBindViewHolder(ViewHolder viewHolder, final int position) {
         viewHolder.binding.editText.setText(mItems.get(position));
+        viewHolder.binding.delete.setVisibility(mVisibility.get(position) ? View.VISIBLE : View.INVISIBLE);
+
+
+        viewHolder.binding.delete.setOnClickListener(v -> {
+            mItems.remove(viewHolder.getAdapterPosition());
+            mVisibility.remove(viewHolder.getAdapterPosition());
+            mVisibility.set(0, mItems.size() > 1);
+            notifyDataSetChanged();
+            onItemRemoved.onItemRemoved(viewHolder.getAdapterPosition());
+        });
+
         viewHolder.binding.editText.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
-            }
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) { }
 
             @Override
             public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
@@ -80,14 +72,28 @@ public class CustomWebsiteRecyclerViewAdapter extends RecyclerView.Adapter<Custo
             }
 
             @Override
-            public void afterTextChanged(Editable editable) {
-
-            }
+            public void afterTextChanged(Editable editable) { }
         });
     }
 
     @Override
     public int getItemCount() {
         return mItems.size();
+    }
+
+    public interface ItemRemovedListener {
+        void onItemRemoved(int position);
+    }
+
+    /**
+     * Provide a reference to the type of views that you are using (custom ViewHolder)
+     */
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+        private final EdittextUrlBinding binding;
+
+        public ViewHolder(EdittextUrlBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+        }
     }
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/adapters/CustomWebsiteRecyclerViewAdapter.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/adapters/CustomWebsiteRecyclerViewAdapter.java
@@ -1,0 +1,93 @@
+package org.openobservatory.ooniprobe.adapters;
+
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.openobservatory.ooniprobe.databinding.EdittextUrlBinding;
+
+import java.util.List;
+
+public class CustomWebsiteRecyclerViewAdapter extends RecyclerView.Adapter<CustomWebsiteRecyclerViewAdapter.ViewHolder> {
+
+    private final List<String> mItems;
+
+    // BEGIN_INCLUDE(recyclerViewSampleViewHolder)
+
+    /**
+     * Provide a reference to the type of views that you are using (custom ViewHolder)
+     */
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+        private final EdittextUrlBinding binding;
+//        private final TextView textView;
+
+        public ViewHolder(EdittextUrlBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+            binding.getRoot().setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+//                    Log.d(TAG, "Element " + getAdapterPosition() + " clicked.");
+                }
+            });
+//            textView = (TextView) v.findViewById(R.id.textView);
+        }
+
+//        public TextView getTextView() {
+//            return textView;
+//        }
+    }
+
+    /**
+     * Initialize the dataset of the Adapter.
+     *
+     * @param dataSet List<String> containing the data to populate views to be used by RecyclerView.
+     */
+    public CustomWebsiteRecyclerViewAdapter(List<String> dataSet) {
+        mItems = dataSet;
+    }
+
+    public void addAll(List<String> dataSet) {
+        mItems.addAll(dataSet);
+    }
+
+    public List<String> getItems() {
+        return mItems;
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
+        EdittextUrlBinding binding = EdittextUrlBinding.inflate(LayoutInflater.from(viewGroup.getContext()), viewGroup, false);
+        return new ViewHolder(binding);
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, final int position) {
+        viewHolder.binding.editText.setText(mItems.get(position));
+        viewHolder.binding.editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                mItems.set(viewHolder.getAdapterPosition(), String.valueOf(charSequence));
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+
+            }
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return mItems.size();
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -21,6 +21,7 @@ import org.openobservatory.ooniprobe.di.ApplicationModule;
 import org.openobservatory.ooniprobe.di.DaggerAppComponent;
 import org.openobservatory.ooniprobe.di.FragmentComponent;
 import org.openobservatory.ooniprobe.di.ServiceComponent;
+import org.openobservatory.ooniprobe.domain.UrlsManager;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 
 import javax.inject.Inject;
@@ -33,7 +34,7 @@ public class Application extends android.app.Application {
 	@Inject Gson _gson;
 	@Inject OkHttpClient _okHttpClient;
 	@Inject OONIAPIClient _apiClient;
-
+	@Inject UrlsManager urlsManager;
 	public AppComponent component;
 
 	@Override public void onCreate() {
@@ -78,6 +79,10 @@ public class Application extends android.app.Application {
 
 	public Gson getGson() {
 		return _gson;
+	}
+
+	public UrlsManager getUrlsManager() {
+		return urlsManager;
 	}
 
 	public boolean isTestRunning() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/UrlsManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/UrlsManager.java
@@ -1,0 +1,48 @@
+package org.openobservatory.ooniprobe.domain;
+
+import org.openobservatory.engine.LoggerArray;
+import org.openobservatory.engine.OONIContext;
+import org.openobservatory.engine.OONISession;
+import org.openobservatory.engine.OONIURLListConfig;
+import org.openobservatory.engine.OONIURLListResult;
+import org.openobservatory.ooniprobe.BuildConfig;
+import org.openobservatory.ooniprobe.common.Application;
+import org.openobservatory.ooniprobe.common.ThirdPartyServices;
+import org.openobservatory.ooniprobe.test.EngineProvider;
+
+import javax.inject.Inject;
+
+public class UrlsManager {
+
+
+    private final Application application;
+
+    @Inject
+    UrlsManager(Application application) {
+        this.application = application;
+    }
+
+    public OONIURLListResult downloadUrls() throws Exception {
+        OONISession session = EngineProvider.get().newSession(EngineProvider.get().getDefaultSessionConfig(
+                application,
+                BuildConfig.SOFTWARE_NAME,
+                BuildConfig.VERSION_NAME,
+                new LoggerArray(),
+                application.getPreferenceManager().getProxyURL()
+        ));
+        OONIContext ooniContext = session.newContextWithTimeout(30);
+
+        ThirdPartyServices.addLogExtra("ooniContext", application.getGson().toJson(ooniContext));
+
+        session.maybeUpdateResources(ooniContext);
+        OONIURLListConfig config = new OONIURLListConfig();
+        config.setCategories(application.getPreferenceManager().getEnabledCategoryArr().toArray(new String[0]));
+
+        ThirdPartyServices.addLogExtra("config", application.getGson().toJson(config));
+
+        OONIURLListResult results = session.fetchURLList(ooniContext, config);
+
+        ThirdPartyServices.addLogExtra("results", application.getGson().toJson(results));
+        return results;
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
@@ -155,21 +155,7 @@ public class TestAsyncTask extends AsyncTask<Void, String, Void> implements Abst
     //This uses the wrapper
     private void downloadURLs() {
         try {
-            OONISession session = EngineProvider.get().newSession(EngineProvider.get().getDefaultSessionConfig(
-                    app, BuildConfig.SOFTWARE_NAME, BuildConfig.VERSION_NAME, new LoggerArray(), proxy));
-            OONIContext ooniContext = session.newContextWithTimeout(30);
-
-            ThirdPartyServices.addLogExtra("ooniContext", app.getGson().toJson(ooniContext));
-
-            session.maybeUpdateResources(ooniContext);
-            OONIURLListConfig config = new OONIURLListConfig();
-            config.setCategories(app.getPreferenceManager().getEnabledCategoryArr().toArray(new String[0]));
-
-            ThirdPartyServices.addLogExtra("config", app.getGson().toJson(config));
-
-            OONIURLListResult results = session.fetchURLList(ooniContext, config);
-
-            ThirdPartyServices.addLogExtra("results", app.getGson().toJson(results));
+            OONIURLListResult results = app.getUrlsManager().downloadUrls();
 
             if (results.getUrls().size() == 0) {
                 publishProgress(ERR, app.getString(R.string.Modal_Error_CantDownloadURLs));

--- a/app/src/main/res/layout/activity_customwebsite.xml
+++ b/app/src/main/res/layout/activity_customwebsite.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
 	android:orientation="vertical">
@@ -17,23 +18,38 @@
 			android:orientation="vertical"
 			android:padding="8dp">
 
-			<LinearLayout
+			<androidx.recyclerview.widget.RecyclerView
 				android:id="@+id/urlContainer"
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"
-				android:animateLayoutChanges="true"
-				android:orientation="vertical" />
+				tools:listitem="@layout/edittext_url"/>
 
-			<Button
-				android:id="@+id/add"
-				style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:text="@string/Settings_Websites_CustomURL_Add"
-				android:textAllCaps="false"
-				android:textColor="@color/color_black"
-				app:icon="@drawable/ic_baseline_add_36"
-				app:iconTint="@color/color_black" />
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content">
+
+				<Button
+					android:id="@+id/add"
+					style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:text="@string/Settings_Websites_CustomURL_Add"
+					android:textAllCaps="false"
+					android:textColor="@color/color_black"
+					app:icon="@drawable/ic_baseline_add_36"
+					app:iconTint="@color/color_black" />
+				<Button
+					android:id="@+id/loadFromWebConnectivity"
+					style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:text="Load from template"
+					android:textAllCaps="false"
+					android:layout_gravity="end"
+					android:textColor="@color/color_black"
+					app:icon="@drawable/ic_baseline_add_36"
+					app:iconTint="@color/color_black" />
+			</LinearLayout>
 		</LinearLayout>
 	</ScrollView>
 

--- a/app/src/main/res/layout/activity_customwebsite.xml
+++ b/app/src/main/res/layout/activity_customwebsite.xml
@@ -47,8 +47,14 @@
 					android:textAllCaps="false"
 					android:layout_gravity="end"
 					android:textColor="@color/color_black"
-					app:icon="@drawable/ic_baseline_add_36"
+					app:icon="@drawable/rerun"
 					app:iconTint="@color/color_black" />
+				<ProgressBar
+					android:id="@+id/progressIndicator"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:visibility="gone"
+					android:indeterminateOnly="true"/>
 			</LinearLayout>
 		</LinearLayout>
 	</ScrollView>

--- a/app/src/main/res/layout/activity_customwebsite.xml
+++ b/app/src/main/res/layout/activity_customwebsite.xml
@@ -43,7 +43,7 @@
 					style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
-					android:text="Load from template"
+					android:text="@string/Settings_Websites_CustomURL_LoadFromTemplate"
 					android:textAllCaps="false"
 					android:layout_gravity="end"
 					android:textColor="@color/color_black"

--- a/app/src/main/res/layout/edittext_url.xml
+++ b/app/src/main/res/layout/edittext_url.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
-	xmlns:app="http://schemas.android.com/apk/res-auto"
-	android:layout_margin="8dp"
 	android:orientation="horizontal">
 
 	<com.google.android.material.textfield.TextInputLayout
-		style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+		style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
+		app:hintEnabled="false"
 		app:errorEnabled="true">
 
 		<com.google.android.material.textfield.TextInputEditText
@@ -19,6 +19,8 @@
 			android:textColor="@android:color/black"
 			android:hint="@string/Settings_Websites_CustomURL_URL"
 			android:inputType="textUri"
+			android:paddingTop="8dp"
+			android:paddingBottom="8dp"
 			android:paddingEnd="48dp"
 			android:text="@string/http" />
 	</com.google.android.material.textfield.TextInputLayout>
@@ -27,10 +29,10 @@
 		android:id="@+id/delete"
 		style="@style/Widget.MaterialComponents.Button.TextButton"
 		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:layout_gravity="end|bottom"
+		android:layout_height="20dp"
+		android:layout_gravity="end|top"
 		android:layout_marginVertical="8dp"
 		android:minWidth="0dp"
 		android:src="@drawable/ic_baseline_remove_circle_24"
-		android:tint="@color/color_red8" />
+		app:tint="@color/color_red8" />
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,6 +409,7 @@
   <string name="Settings_Websites_CustomURL_NoURLEntered">No URLs entered</string>
   <string name="Settings_Websites_CustomURL_Run">Run</string>
   <string name="Settings_Websites_CustomURL_Add">Add website</string>
+  <string name="Settings_Websites_CustomURL_LoadFromTemplate">Load from template</string>
   <string name="Settings_Websites_TestCount">Number of tested websites (0 means all)</string>
   <string name="Settings_InstantMessaging_TestWhatsApp">Test WhatsApp</string>
   <string name="Settings_InstantMessaging_TestTelegram">Test Telegram</string>


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/1929 , https://github.com/ooni/probe/issues/1935

## Proposed Changes

  -  Added Support for android `viewBinding`.
  - Add button to load websites (`loadFromWebConnectivity`) used in `web_connectivity` test in `CustomWebsiteActivity`.
  - Fetch and display websites in webconnectivity when `loadFromWebConnectivity` button is clicked, making `loadFromWebConnectivity` invisible when successful.

| . | . |  . |
| --- | --- | --- |
| ![Screenshot_20220402_075718](https://user-images.githubusercontent.com/17911892/161371785-a4f1f2c8-1bf6-442f-a0dd-08e97b431b99.png) | ![Screenshot_20220402_075743](https://user-images.githubusercontent.com/17911892/161371783-bfc1bb1c-4f11-4be1-9fdb-53982b3d1f57.png) | ![Screenshot_20220402_075758](https://user-images.githubusercontent.com/17911892/161371781-2d86091c-83aa-4bd5-8cb2-346a97da31da.png)  |


