### PR TITLE
Add cancel dialog to upload progress

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/DialogUtil.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/DialogUtil.java
@@ -1,0 +1,25 @@
+package org.openobservatory.ooniprobe.common;
+
+import android.app.ProgressDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+
+public class DialogUtil {
+    public static ProgressDialog makeProgressDialog(Context context, String message, boolean cancelable, DialogInterface.OnClickListener cancelListener) {
+        ProgressDialog pd = new ProgressDialog(context, org.openobservatory.ooniprobe.R.style.MaterialAlertDialogCustom);
+        pd.setTitle(localhost.toolkit.R.string.prgsTitle);
+        if (message != null) {
+            pd.setMessage(message);
+        }
+        pd.setCancelable(cancelable);
+
+        if (cancelable) {
+            pd.setButton(
+                    DialogInterface.BUTTON_NEGATIVE,
+                    context.getText(org.openobservatory.ooniprobe.R.string.Modal_Cancel),
+                    cancelListener
+            );
+        }
+        return pd;
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
@@ -1,7 +1,9 @@
 package org.openobservatory.ooniprobe.common;
 
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 
 import androidx.annotation.VisibleForTesting;
@@ -41,6 +43,9 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
     @VisibleForTesting
     // In testing, publishProgress can not be mocked by robolectric
     protected boolean publishProgress = true;
+    protected boolean interrupted = false;
+
+    private final ProgressDialog progressDialog;
 
     /**
      * Use this class to resubmit a measurement, use result_id and measurement_id to filter list of value
@@ -49,12 +54,21 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
      * @param activity from which this task are executed
      */
     public ResubmitTask(A activity, String proxyURL) {
-        super(activity, true, false);
+        super(activity, false, false);
         activity.getComponent().serviceComponent().inject(d);
+        progressDialog = DialogUtil.makeProgressDialog(activity, activity.getString(localhost.toolkit.R.string.prgsMessage), true, (dialog, which) -> {
+            dialog.dismiss();
+            interrupted = true;
+            cancel(true);
+        });
         proxy = proxyURL;
     }
 
-    private boolean perform(Context c, Measurement m, OONISession session)  {
+    public static long getTimeout(long length) {
+        return length / 2000 + 10;
+    }
+
+    private boolean perform(Context c, Measurement m, OONISession session) {
         File file = Measurement.getEntryFile(c, m.id, m.test_name);
         String input;
         long uploadTimeout = getTimeout(file.length());
@@ -75,14 +89,18 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
         }
     }
 
-    public static long getTimeout(long length) {
-        return length / 2000 + 10;
-    }
-
     @Override
     protected void onPreExecute() {
         super.onPreExecute();
         A activity = getActivity();
+        if (getActivity() != null) {
+            InputMethodManager inputMethodManager = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (inputMethodManager != null)
+                inputMethodManager.hideSoftInputFromWindow(getActivity().getWindow().getDecorView().getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+            if (progressDialog != null) {
+                progressDialog.show();
+            }
+        }
         if (activity != null)
             activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
@@ -121,6 +139,8 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
             // and there should be no timeout here.)
             session.maybeUpdateResources(session.newContext());
             for (int i = 0; i < measurements.size(); i++) {
+                if (interrupted) break;
+
                 A activity = getActivity();
                 if (activity ==  null)
                     break;
@@ -143,6 +163,14 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
         return errors == 0;
     }
 
+
+    @Override
+    protected void onProgressUpdate(String... values) {
+        super.onProgressUpdate(values);
+        if (progressDialog != null)
+            progressDialog.setMessage(values[0]);
+    }
+
     @Override
     protected void onPostExecute(Boolean result) {
         super.onPostExecute(result);
@@ -151,6 +179,23 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
             Toast.makeText(activity, activity.getString(R.string.Toast_ResultsUploaded), Toast.LENGTH_SHORT).show();
             activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         }
+        onFinish();
+    }
+
+
+    @Override
+    protected void onCancelled(Boolean result) {
+        super.onCancelled(result);
+        onFinish();
+    }
+
+    private void onFinish() {
+        if (progressDialog != null)
+            try {
+                progressDialog.dismiss();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
     }
 
     public static class Dependencies {

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -283,7 +283,8 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
             super.onPostExecute(result);
             ResultListFragment f = wf.get();
             if (getActivity() != null && f != null) {
-                f.queryList();
+                if (f.isAdded())
+                    f.queryList();
                 if (!result)
                     new ConfirmDialogFragment.Builder()
                             .withTitle(getActivity().getString(R.string.Modal_UploadFailed_Title))

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -61,7 +61,7 @@
 		<item name="android:textColor">@color/color_black</item>
 		<item name="android:textColorPrimary">@color/color_gray9</item>
 		<item name="android:background">@color/color_white</item>
-		<item name="colorAccent">@color/color_teal3</item>
+		<item name="colorAccent">@color/color_blue4</item>
 	</style>
 
 	<style name="SnackBarStyle" parent="Widget.MaterialComponents.Snackbar">


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/1252

## Proposed Changes

  - Add `DialogUtil.makeProgressDialog` to create dialog.
  - Modified `ResubmitTask` constructor call to super [`NetworkProgressAsyncTask`](https://github.com/xanscale/LocalhostToolkit/blob/19.05.01/app/src/main/java/localhost/toolkit/os/NetworkProgressAsyncTask.java#L13) ,  [`ProgressAsyncTask`](https://github.com/xanscale/LocalhostToolkit/blob/19.05.01/app/src/main/java/localhost/toolkit/os/ProgressAsyncTask.java#L20-L24) to disable dialog.
  - Initialize progress dialog and receive progress in `ResubmitTask` as required.

| . | . | . |
| --- | --- | --- |
| ![Screenshot_20220402_190910](https://user-images.githubusercontent.com/17911892/161396080-5adfb11b-edae-41a0-bfc1-6e8aedce8cee.png) | ![Screenshot_20220402_190834](https://user-images.githubusercontent.com/17911892/161396081-367e0287-c1be-4829-bcc9-180632f1c4f5.png) | ![Screenshot_20220402_190745](https://user-images.githubusercontent.com/17911892/161396082-f1a7d19f-1b9c-46da-aada-a9c1df6af6d2.png) |

