### PR TITLE
Do not display VPN warnings when VPN warnings option is disabled

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/CustomWebsiteActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/CustomWebsiteActivity.java
@@ -63,7 +63,7 @@ public class CustomWebsiteActivity extends AbstractActivity implements ConfirmDi
             WebsitesSuite suite = new WebsitesSuite();
             suite.getTestList(preferenceManager)[0].setInputs(urls);
 
-            RunningActivity.runAsForegroundService(CustomWebsiteActivity.this, suite.asArray(), this::finish);
+            RunningActivity.runAsForegroundService(CustomWebsiteActivity.this, suite.asArray(), this::finish, preferenceManager);
             return true;
         });
         add();

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OoniRunActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OoniRunActivity.java
@@ -150,7 +150,7 @@ public class OoniRunActivity extends AbstractActivity {
 		}
 		run.setOnClickListener(v -> {
 
-			RunningActivity.runAsForegroundService(OoniRunActivity.this, suite.asArray(),this::finish);
+			RunningActivity.runAsForegroundService(OoniRunActivity.this, suite.asArray(),this::finish, preferenceManager);
 
 		});
 	}

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
@@ -87,7 +87,7 @@ public class OverviewActivity extends AbstractActivity {
 	}
 
 	@OnClick(R.id.run) void onRunClick() {
-		RunningActivity.runAsForegroundService(this, testSuite.asArray(), this::bindTestService);
+		RunningActivity.runAsForegroundService(this, testSuite.asArray(), this::bindTestService, preferenceManager);
 	}
 
 	@OnClick(R.id.customUrl) void customUrlClick() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/ResultDetailActivity.java
@@ -26,6 +26,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
 import org.openobservatory.ooniprobe.R;
+import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ResubmitTask;
 import org.openobservatory.ooniprobe.domain.GetResults;
 import org.openobservatory.ooniprobe.domain.GetTestSuite;
@@ -81,6 +82,9 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
 
     @Inject
     GetResults getResults;
+
+    @Inject
+    PreferenceManager preferenceManager;
 
     public static Intent newIntent(Context context, int id) {
         return new Intent(context, ResultDetailActivity.class).putExtra(ID, id);
@@ -153,7 +157,7 @@ public class ResultDetailActivity extends AbstractActivity implements View.OnCli
     }
 
     private void reTestWebsites() {
-        RunningActivity.runAsForegroundService(this, getTestSuite.getFrom(result).asArray(),this::finish);
+        RunningActivity.runAsForegroundService(this, getTestSuite.getFrom(result).asArray(),this::finish, preferenceManager);
     }
 
     private void runAsyncTask() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
@@ -89,7 +89,7 @@ public class RunningActivity extends AbstractActivity implements ConfirmDialogFr
     public static void runAsForegroundService(AbstractActivity context,
                                               ArrayList<AbstractSuite> testSuites,
                                               OnTestServiceStartedListener onTestServiceStartedListener,
-                                              PreferenceManager _preferenceManager) {
+                                              PreferenceManager iPreferenceManager) {
         if (ReachabilityManager.getNetworkType(context).equals(ReachabilityManager.NO_INTERNET)) {
             new MessageDialogFragment.Builder()
                     .withTitle(context.getString(R.string.Modal_Error))
@@ -100,11 +100,15 @@ public class RunningActivity extends AbstractActivity implements ConfirmDialogFr
                     .withTitle(context.getString(R.string.Modal_Error))
                     .withMessage(context.getString(R.string.Modal_Error_TestAlreadyRunning))
                     .build().show(context.getSupportFragmentManager(), null);
-        } else if (ReachabilityManager.isVPNinUse(context) && _preferenceManager.isUploadResults()) {
+        } else if (ReachabilityManager.isVPNinUse(context) && iPreferenceManager.isWarnVPNInUse()) {
             new AlertDialog.Builder(context, R.style.MaterialAlertDialogCustom)
                     .setTitle(context.getString(R.string.Modal_DisableVPN_Title))
                     .setMessage(context.getString(R.string.Modal_DisableVPN_Message))
-                    .setNegativeButton(R.string.Modal_RunAnyway, (dialogInterface, i) -> {
+                    .setNeutralButton(R.string.Modal_RunAnyway, (dialogInterface, i) -> {
+                        startRunTestService(context, testSuites,onTestServiceStartedListener);
+                    })
+                    .setNegativeButton(R.string.Modal_AlwaysRun,(dialog, which) -> {
+                        iPreferenceManager.setWarnVPNInUse(false);
                         startRunTestService(context, testSuites,onTestServiceStartedListener);
                     })
                     .setPositiveButton(R.string.Modal_DisableVPN, (dialogInterface, i) -> {

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
@@ -88,7 +88,8 @@ public class RunningActivity extends AbstractActivity implements ConfirmDialogFr
      */
     public static void runAsForegroundService(AbstractActivity context,
                                               ArrayList<AbstractSuite> testSuites,
-                                              OnTestServiceStartedListener onTestServiceStartedListener) {
+                                              OnTestServiceStartedListener onTestServiceStartedListener,
+                                              PreferenceManager _preferenceManager) {
         if (ReachabilityManager.getNetworkType(context).equals(ReachabilityManager.NO_INTERNET)) {
             new MessageDialogFragment.Builder()
                     .withTitle(context.getString(R.string.Modal_Error))
@@ -99,7 +100,7 @@ public class RunningActivity extends AbstractActivity implements ConfirmDialogFr
                     .withTitle(context.getString(R.string.Modal_Error))
                     .withMessage(context.getString(R.string.Modal_Error_TestAlreadyRunning))
                     .build().show(context.getSupportFragmentManager(), null);
-        } else if (ReachabilityManager.isVPNinUse(context)) {
+        } else if (ReachabilityManager.isVPNinUse(context) && _preferenceManager.isUploadResults()) {
             new AlertDialog.Builder(context, R.style.MaterialAlertDialogCustom)
                     .setTitle(context.getString(R.string.Modal_DisableVPN_Title))
                     .setMessage(context.getString(R.string.Modal_DisableVPN_Message))

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
@@ -131,6 +131,13 @@ public class PreferenceManager {
 		return sp.getBoolean(r.getString(R.string.upload_results), true);
 	}
 
+	public boolean isWarnVPNInUse() {
+		return sp.getBoolean(r.getString(R.string.warn_vpn_in_use), false);
+	}
+
+	public void setWarnVPNInUse(Boolean warnVPNInUse) {
+		sp.edit().putBoolean(r.getString(R.string.warn_vpn_in_use), warnVPNInUse).apply();
+	}
 	public boolean isDebugLogs() {
 		return sp.getBoolean(r.getString(R.string.debugLogs), false);
 	}

--- a/app/src/main/java/org/openobservatory/ooniprobe/di/FragmentComponent.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/di/FragmentComponent.java
@@ -1,6 +1,7 @@
 package org.openobservatory.ooniprobe.di;
 
 import org.openobservatory.ooniprobe.di.annotations.PerActivity;
+import org.openobservatory.ooniprobe.fragment.DashboardFragment;
 import org.openobservatory.ooniprobe.fragment.ProgressFragment;
 import org.openobservatory.ooniprobe.fragment.ResultListFragment;
 import org.openobservatory.ooniprobe.fragment.onboarding.Onboarding3Fragment;
@@ -11,6 +12,7 @@ import dagger.Subcomponent;
 @PerActivity
 @Subcomponent()
 public interface FragmentComponent {
+    void inject(DashboardFragment fragment);
     void inject(Onboarding3Fragment fragment);
     void inject(ResultListFragment fragment);
     void inject(ProgressFragment fragment);

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.java
@@ -80,7 +80,7 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
 		setLastTest();
 		adapter.notifyTypesChanged();
 		if (ReachabilityManager.isVPNinUse(this.getContext())
-				&& preferenceManager.isUploadResults())
+				&& preferenceManager.isWarnVPNInUse())
 			vpn.setVisibility(View.VISIBLE);
 		else
 			vpn.setVisibility(View.GONE);

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.java
@@ -19,9 +19,11 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.activity.AbstractActivity;
+import org.openobservatory.ooniprobe.activity.MainActivity;
 import org.openobservatory.ooniprobe.activity.OverviewActivity;
 import org.openobservatory.ooniprobe.activity.RunningActivity;
 import org.openobservatory.ooniprobe.common.Application;
+import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ReachabilityManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.item.TestsuiteItem;
@@ -30,6 +32,9 @@ import org.openobservatory.ooniprobe.test.TestAsyncTask;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
 
 import java.util.ArrayList;
+import java.util.Objects;
+
+import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -42,6 +47,9 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
     @BindView(R.id.run_all) TextView runAll;
 	@BindView(R.id.vpn) TextView vpn;
 
+	@Inject
+	PreferenceManager preferenceManager;
+
 	private ArrayList<TestsuiteItem> items;
 	private ArrayList<AbstractSuite> testSuites;
 	private HeterogeneousRecyclerAdapter<TestsuiteItem> adapter;
@@ -49,6 +57,7 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
 	@Nullable @Override public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
 		View v = inflater.inflate(R.layout.fragment_dashboard, container, false);
 		ButterKnife.bind(this, v);
+		((Application) getActivity().getApplication()).getFragmentComponent().inject(this);
 		((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
 		((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(null);
 		items = new ArrayList<>();
@@ -70,7 +79,8 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
 			items.add(new TestsuiteItem(testSuite, this));
 		setLastTest();
 		adapter.notifyTypesChanged();
-		if (ReachabilityManager.isVPNinUse(this.getContext()))
+		if (ReachabilityManager.isVPNinUse(this.getContext())
+				&& preferenceManager.isUploadResults())
 			vpn.setVisibility(View.VISIBLE);
 		else
 			vpn.setVisibility(View.GONE);
@@ -89,7 +99,7 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
 	}
 
     public void runAll() {
-        RunningActivity.runAsForegroundService((AbstractActivity) getActivity(), testSuites, this::onTestServiceStartedListener);
+        RunningActivity.runAsForegroundService((AbstractActivity) getActivity(), testSuites, this::onTestServiceStartedListener, preferenceManager);
     }
 
     private void onTestServiceStartedListener() {
@@ -108,7 +118,8 @@ public class DashboardFragment extends Fragment implements View.OnClickListener 
                 RunningActivity.runAsForegroundService(
                         (AbstractActivity) getActivity(),
                         testSuite.asArray(),
-                        this::onTestServiceStartedListener
+                        this::onTestServiceStartedListener,
+						preferenceManager
                 );
 				break;
 			default:

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.activity.AbstractActivity;
 import org.openobservatory.ooniprobe.activity.RunningActivity;
+import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
@@ -19,11 +20,16 @@ import org.openobservatory.ooniprobe.test.test.AbstractTest;
 
 import java.util.Collections;
 
+import javax.inject.Inject;
+
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 
 public class FailedFragment extends Fragment {
 	private static final String MEASUREMENT = "measurement";
+
+	@Inject
+	PreferenceManager preferenceManager;
 
 	public static FailedFragment newInstance(Measurement measurement) {
 		Bundle args = new Bundle();
@@ -61,6 +67,6 @@ public class FailedFragment extends Fragment {
 						exception.printStackTrace();
 						ThirdPartyServices.logException(exception);
 					}
-				});
+				},preferenceManager);
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
   <string name="Modal_NotNow">Not now</string>
   <string name="Modal_RunAnyway">Run anyways</string>
   <string name="Modal_DisableVPN">Disable VPN</string>
+  <string name="Modal_AlwaysRun">Always Run</string>
   <string name="Modal_Error_NoInternet">Unable to run the test. Please check your internet connectivity.</string>
   <string name="Modal_Error_CantDownloadURLs">Unable to download URL list. Please try again.</string>
   <string name="Modal_Error_TestAlreadyRunning">Please wait for the current running tests to finish, before starting a new test.</string>
@@ -427,6 +428,7 @@
   <string name="Settings_Circumvention_TestPsiphon">Test Psiphon</string>
   <string name="Settings_Circumvention_TestTor">Test Tor</string>
   <string name="Settings_Circumvention_TestRiseupVPN">Test RiseupVPN</string>
+  <string name="Settings_WarmVPNInUse_Label">Warn when VPN is in use</string>
   <string name="Settings_SendEmail_Label">Send email to support</string>
   <string name="Settings_SendEmail_Message">Please describe the problem you are experiencing:</string>
   <string name="Settings_SendEmail_Error">Please send an email to bugs@openobservatory.org with information on the app and iOS version. Tap \"Copy to clipboard\" below to copy our email address.</string>

--- a/app/src/main/res/values/untraslatable.xml
+++ b/app/src/main/res/values/untraslatable.xml
@@ -37,6 +37,7 @@
 	<string name="debugLogs" translatable="false">debugLogs</string>
 	<string name="storage_usage" translatable="false">storage_usage</string>
 	<string name="send_crash" translatable="false">send_crash</string>
+	<string name="warn_vpn_in_use" translatable="false">warn_vpn_in_use</string>
 	<string name="run_http_invalid_request_line" translatable="false">run_http_invalid_request_line</string>
 	<string name="run_http_header_field_manipulation" translatable="false">run_http_header_field_manipulation</string>
 	<string name="test_whatsapp" translatable="false">test_whatsapp</string>

--- a/app/src/main/res/xml/preferences_global.xml
+++ b/app/src/main/res/xml/preferences_global.xml
@@ -358,6 +358,11 @@
 			android:summary=""
 			android:widgetLayout="@layout/preference_button"
 			app:iconSpaceReserved="false" />
+		<SwitchPreferenceCompat
+			android:defaultValue="true"
+			android:key="@string/warn_vpn_in_use"
+			android:title="@string/Settings_WarmVPNInUse_Label"
+			app:iconSpaceReserved="false" />
 	</PreferenceScreen>
 	<PreferenceScreen
 		android:icon="@drawable/send_email"


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2015 
Replaces https://github.com/ooni/probe-android/pull/498

## Proposed Changes

  -  Update service `RunningActivity` to only show modal when `VPN` and `warn_vpn_in_use` are enabled.
  -  Update VPN warning modal to add option to `Always Run`
  
| Light Theme      | Dark Theme |
| ----------- | ----------- |
| ![Screenshot_20220314_145729](https://user-images.githubusercontent.com/17911892/158188319-d666e745-576d-453d-b932-6acbeeb47dcb.png) | ![Screenshot_20220314_145709](https://user-images.githubusercontent.com/17911892/158188403-e6b58682-9b13-4573-9e99-07bfee5530c9.png) |
|  ![Screenshot_20220314_145847](https://user-images.githubusercontent.com/17911892/158188569-c2fd54b2-ef68-474a-bd89-456e791b559f.png) |  ![Screenshot_20220314_145826](https://user-images.githubusercontent.com/17911892/158188687-fab12d4e-4f8f-4668-b5e8-203dc2a1deab.png)  |

