### PR TITLE
Add support for in-app language selection

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/AbstractActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/AbstractActivity.java
@@ -7,6 +7,7 @@ import com.google.gson.Gson;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.client.OONIAPIClient;
 import org.openobservatory.ooniprobe.common.Application;
+import org.openobservatory.ooniprobe.common.LocaleUtils;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.di.ActivityComponent;
 import org.openobservatory.ooniprobe.di.AppComponent;
@@ -15,7 +16,9 @@ import org.openobservatory.ooniprobe.fragment.ProgressFragment;
 import okhttp3.OkHttpClient;
 
 public abstract class AbstractActivity extends AppCompatActivity {
-
+    public AbstractActivity() {
+        LocaleUtils.updateConfig(this);
+    }
     public Application getApp() {
         return ((Application) getApplication());
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -23,6 +23,8 @@ import org.openobservatory.ooniprobe.di.FragmentComponent;
 import org.openobservatory.ooniprobe.di.ServiceComponent;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 
+import java.util.Locale;
+
 import javax.inject.Inject;
 
 import okhttp3.OkHttpClient;
@@ -50,6 +52,9 @@ public class Application extends android.app.Application {
 			Measurement.deleteUploadedJsons(this);
 		Measurement.deleteOldLogs(this);
 		ThirdPartyServices.reloadConsents(this);
+
+		LocaleUtils.setLocale(new Locale(_preferenceManager.getSettingsLanguage()));
+		LocaleUtils.updateConfig(this, getBaseContext().getResources().getConfiguration());
 	}
 
 	protected AppComponent buildDagger() {

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/LocaleUtils.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/LocaleUtils.java
@@ -1,0 +1,40 @@
+package org.openobservatory.ooniprobe.common;
+
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.view.ContextThemeWrapper;
+
+import java.util.Locale;
+
+public class LocaleUtils {
+
+
+    private static Locale sLocale;
+
+    public static void setLocale(Locale locale) {
+        sLocale = locale;
+        if (sLocale != null) {
+            Locale.setDefault(sLocale);
+        }
+    }
+
+    public static void updateConfig(ContextThemeWrapper wrapper) {
+        if (sLocale != null) {
+            Configuration configuration = new Configuration();
+            configuration.setLocale(sLocale);
+            wrapper.applyOverrideConfiguration(configuration);
+        }
+    }
+
+
+    public static void updateConfig(Application app, Configuration configuration) {
+        if(sLocale != null) {
+            //Wrapping the configuration to avoid Activity endless loop
+            Configuration config = new Configuration(configuration);
+            config.locale = sLocale;
+            Resources res = app.getBaseContext().getResources();
+            res.updateConfiguration(config, res.getDisplayMetrics());
+        }
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
@@ -309,6 +309,14 @@ public class PreferenceManager {
 		return sp.getBoolean(r.getString(R.string.automated_testing_enabled), false);
 	}
 
+	public String getSettingsLanguage() {
+		String language = sp.getString(r.getString(R.string.language_setting), Locale.getDefault().getLanguage());
+		if (language.equals("auto")) {
+			return Locale.getDefault().getLanguage();
+		}
+		return language;
+	}
+
 	public void enableAutomatedTesting() {
 		sp.edit().putBoolean(r.getString(R.string.automated_testing_enabled), true)
 				.apply();

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/PreferenceFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/PreferenceFragment.java
@@ -1,5 +1,6 @@
 package org.openobservatory.ooniprobe.fragment;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -189,7 +190,7 @@ public class PreferenceFragment extends ExtendedPreferenceFragment<PreferenceFra
                 checkAtLeastOneEnabled(sharedPreferences, key);
         }
 
-        if (key.equals(getString(R.string.theme_enabled))) {
+        if (key.equals(getString(R.string.theme_enabled)) || key.equals(getString(R.string.language_setting))) {
             Toast.makeText(getActivity(), "Please restart the app for apply changes.", Toast.LENGTH_LONG).show();
             getActivity().finishAffinity();
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
   <string name="Modal_NotNow">Not now</string>
   <string name="Modal_RunAnyway">Run anyways</string>
   <string name="Modal_DisableVPN">Disable VPN</string>
+  <string name="Modal_AlwaysRun">Always Run</string>
   <string name="Modal_Error_NoInternet">Unable to run the test. Please check your internet connectivity.</string>
   <string name="Modal_Error_CantDownloadURLs">Unable to download URL list. Please try again.</string>
   <string name="Modal_Error_TestAlreadyRunning">Please wait for the current running tests to finish, before starting a new test.</string>
@@ -376,6 +377,8 @@
   <string name="Settings_Advanced_Label">Advanced</string>
   <string name="Settings_DarkMode_Label">Dark Mode</string>
   <string name="Settings_Advanced_DebugLogs">Debug logs</string>
+  <string name="Settings_Advanced_LanguageSettings_Title">Language Setting</string>
+  <string name="Settings_Advanced_LanguageSettings_PopUp">Select Language</string>
   <string name="Settings_Advanced_UseDomainFronting">Always use domain fronting</string>
   <string name="Settings_Proxy_Label">OONI backend proxy</string>
   <string name="Settings_Proxy_Enabled">Proxy</string>

--- a/app/src/main/res/values/untraslatable.xml
+++ b/app/src/main/res/values/untraslatable.xml
@@ -253,4 +253,57 @@
 		<item>@drawable/category_igo</item>
 		<item>@drawable/category_misc</item>
 	</array>
+	<string name="language_setting" translatable="false">language_setting</string>
+	<string-array name="language_sort_options">
+		<item>Automatic</item>
+		<item>Arabic</item>
+		<item>Catalan</item>
+		<item>German</item>
+		<item>Greek</item>
+		<item>Spanish</item>
+		<item>English</item>
+		<item>Farsi</item>
+		<item>French</item>
+		<item>Hindi</item>
+		<item>Indonesian</item>
+		<item>Icelandic</item>
+		<item>Italian</item>
+		<item>Dutch</item>
+		<item>Portuguese</item>
+		<item>Romanian</item>
+		<item>Russian</item>
+		<item>Swahili</item>
+		<item>Slovak</item>
+		<item>Albanian</item>
+		<item>Thai</item>
+		<item>Turkish</item>
+		<item>Chinese (S)</item>
+		<item>Chinese (T)</item>
+	</string-array>
+	<string-array name="language_sort_options_values">
+		<item>auto</item>
+		<item>ar</item>
+		<item>ca</item>
+		<item>de</item>
+		<item>el</item>
+		<item>es</item>
+		<item>en</item>
+		<item>fa</item>
+		<item>fr</item>
+		<item>hi</item>
+		<item>id</item>
+		<item>is</item>
+		<item>it</item>
+		<item>nl</item>
+		<item>pt_BR</item>
+		<item>ro</item>
+		<item>ru</item>
+		<item>sw</item>
+		<item>sk</item>
+		<item>sq</item>
+		<item>th</item>
+		<item>tr</item>
+		<item>zh_CN</item>
+		<item>zh_TW</item>
+	</string-array>
 </resources>

--- a/app/src/main/res/xml/preferences_global.xml
+++ b/app/src/main/res/xml/preferences_global.xml
@@ -347,6 +347,15 @@
 			android:key="@string/theme_enabled"
 			android:title="@string/Settings_DarkMode_Label"
 			app:iconSpaceReserved="false" />
+		<ListPreference
+			android:dialogTitle="@string/Settings_Advanced_LanguageSettings_PopUp"
+			android:entries="@array/language_sort_options"
+			android:entryValues="@array/language_sort_options_values"
+			android:key="@string/language_setting"
+			android:summary=""
+			android:title="@string/Settings_Advanced_LanguageSettings_Title"
+			android:defaultValue="auto"
+			app:iconSpaceReserved="false"/>
 		<SwitchPreferenceCompat
 			android:defaultValue="false"
 			android:key="@string/debugLogs"


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/1933 on android
Replaces https://github.com/ooni/probe-android/pull/499

## Proposed Changes

  - Add Language preference to `Advanced Settings`.
  - Add `LocaleUtils` to hold localization helper methods.
  - Update `PreferenceFragment.onSharedPreferenceChanged` to exit and prompt user to close app to reapply settings.

| .  | . | .  | . |
| ----------- | ----------- |----------- | ----------- |
|  ![Screenshot_20220318_230922](https://user-images.githubusercontent.com/17911892/159091262-960ff1af-bcdd-4515-9006-d39c8ac92fed.png)  | ![Screenshot_20220318_230911](https://user-images.githubusercontent.com/17911892/159091267-c6426489-b75d-48bc-8975-d8f4abfd1f92.png) | ![Screenshot_20220318_230821](https://user-images.githubusercontent.com/17911892/159091268-b9a856e6-b8a5-495d-a8d2-91109cf70fa2.png) |  ![Screenshot_20220318_230806](https://user-images.githubusercontent.com/17911892/159091273-041b186e-324b-47d8-bf77-4b544b239027.png)  |

