### PR TITLE
Add cancel dialog to upload progress

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,6 +114,14 @@
 			android:screenOrientation="userPortrait"
 			android:theme="@style/Theme.MaterialComponents.Light.NoActionBar.App">
 			<intent-filter>
+				<action android:name="android.intent.action.SEND" />
+				<category android:name="android.intent.category.DEFAULT" />
+
+				<action android:name="org.openobservatory.ooniprobe.nettest" />
+
+				<data android:mimeType="text/plain" />
+			</intent-filter>
+			<intent-filter>
 				<action android:name="android.intent.action.VIEW" />
 
 				<category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OoniRunActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OoniRunActivity.java
@@ -3,6 +3,7 @@ package org.openobservatory.ooniprobe.activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Patterns;
 import android.view.View;
 import android.webkit.URLUtil;
 import android.widget.Button;
@@ -27,6 +28,8 @@ import org.openobservatory.ooniprobe.item.TextItem;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -94,6 +97,20 @@ public class OoniRunActivity extends AbstractActivity {
 			String ta = uri == null ? null : uri.getQueryParameter("ta");
 			loadScreen(mv, tn, ta);
 		}
+		else if (Intent.ACTION_SEND.equals(intent.getAction())) {
+			String url = intent.getStringExtra(Intent.EXTRA_TEXT);
+			if (url != null && Patterns.WEB_URL.matcher(url).matches()) {
+				List<String> urls = Collections.singletonList(url);
+				AbstractSuite suite = getSuite.get("web_connectivity", urls);
+				if (suite != null) {
+					loadSuite(suite, urls);
+				} else {
+					loadInvalidAttributes();
+				}
+			} else {
+				loadInvalidAttributes();
+			}
+		}
 	}
 
 	private void loadScreen(String mv, String tn, String ta){
@@ -103,9 +120,13 @@ public class OoniRunActivity extends AbstractActivity {
 			if (versionCompare.compare(version_name, mv) >= 0) {
 				try {
 					Attribute attribute = gson.fromJson(ta, Attribute.class);
-					AbstractSuite suite = getSuite.get(tn, attribute);
-					if (suite != null) {
-						loadSuite(suite, attribute);
+					if (attribute!=null){
+						AbstractSuite suite = getSuite.get(tn, attribute.urls);
+						if (suite != null) {
+							loadSuite(suite, attribute.urls);
+						} else {
+							loadInvalidAttributes();
+						}
 					} else {
 						loadInvalidAttributes();
 					}
@@ -133,12 +154,12 @@ public class OoniRunActivity extends AbstractActivity {
 		});
 	}
 
-	private void loadSuite(AbstractSuite suite, Attribute attribute) {
+	private void loadSuite(AbstractSuite suite, List<String> urls) {
 		icon.setImageResource(suite.getIcon());
 		title.setText(suite.getTestList(preferenceManager)[0].getLabelResId());
 		desc.setText(getString(R.string.OONIRun_YouAreAboutToRun));
-		if (attribute != null && attribute.urls != null) {
-			for (String url : attribute.urls) {
+		if (urls != null) {
+			for (String url : urls) {
 				if (URLUtil.isValidUrl(url))
 					items.add(new TextItem(url));
 			}

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/GetTestSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/GetTestSuite.java
@@ -24,9 +24,9 @@ public class GetTestSuite {
         this.application = application;
     }
 
-    public AbstractSuite get(String testName, @Nullable Attribute attribute) {
+    public AbstractSuite get(String testName, @Nullable List<String> urls) {
         return AbstractSuite.getSuite(application, testName,
-                attribute == null ? null : attribute.urls,
+                urls,
                 "ooni-run");
     }
 


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/1252

## Proposed Changes

  - Add `DialogUtil.makeProgressDialog` to create dialog.
  - Modified `ResubmitTask` constructor call to super [`NetworkProgressAsyncTask`](https://github.com/xanscale/LocalhostToolkit/blob/19.05.01/app/src/main/java/localhost/toolkit/os/NetworkProgressAsyncTask.java#L13) ,  [`ProgressAsyncTask`](https://github.com/xanscale/LocalhostToolkit/blob/19.05.01/app/src/main/java/localhost/toolkit/os/ProgressAsyncTask.java#L20-L24) to disable dialog.
  - Initialize progress dialog and receive progress in `ResubmitTask` as required.

| . | . | . |
| --- | --- | --- |
| ![Screenshot_20220402_190910](https://user-images.githubusercontent.com/17911892/161396080-5adfb11b-edae-41a0-bfc1-6e8aedce8cee.png) | ![Screenshot_20220402_190834](https://user-images.githubusercontent.com/17911892/161396081-367e0287-c1be-4829-bcc9-180632f1c4f5.png) | ![Screenshot_20220402_190745](https://user-images.githubusercontent.com/17911892/161396082-f1a7d19f-1b9c-46da-aada-a9c1df6af6d2.png) |

