### PR TITLE
 when you attempt to re-run a failed test while a test is running the row is deleted

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
@@ -9,11 +9,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.activity.AbstractActivity;
 import org.openobservatory.ooniprobe.activity.RunningActivity;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
+import org.openobservatory.ooniprobe.databinding.FragmentMeasurementFailedBinding;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
 import org.openobservatory.ooniprobe.test.test.AbstractTest;
@@ -22,14 +22,12 @@ import java.util.Collections;
 
 import javax.inject.Inject;
 
-import butterknife.ButterKnife;
-import butterknife.OnClick;
-
 public class FailedFragment extends Fragment {
 	private static final String MEASUREMENT = "measurement";
 
 	@Inject
 	PreferenceManager preferenceManager;
+	private FragmentMeasurementFailedBinding binding;
 
 	public static FailedFragment newInstance(Measurement measurement) {
 		Bundle args = new Bundle();
@@ -40,12 +38,12 @@ public class FailedFragment extends Fragment {
 	}
 
 	@Nullable @Override public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
-		View v = inflater.inflate(R.layout.fragment_measurement_failed, container, false);
-		ButterKnife.bind(this, v);
-		return v;
+		binding = FragmentMeasurementFailedBinding.inflate(inflater,container,false);
+		binding.tryAgain.setOnClickListener(this::tryAgainClick);
+		return binding.getRoot();
 	}
 
-	@OnClick(R.id.tryAgain) void tryAgainClick() {
+ void tryAgainClick(View view) {
 		assert getArguments() != null;
 		Measurement failedMeasurement = (Measurement) getArguments().getSerializable(MEASUREMENT);
 		assert failedMeasurement != null;
@@ -56,12 +54,12 @@ public class FailedFragment extends Fragment {
 		AbstractSuite testSuite = failedMeasurement.result.getTestSuite();
 		testSuite.setTestList(abstractTest);
 		testSuite.setResult(failedMeasurement.result);
-		failedMeasurement.setReRun(getContext());
 
 		RunningActivity.runAsForegroundService((AbstractActivity) getActivity(),
 				testSuite.asArray(),
 				() -> {
 					try {
+						failedMeasurement.setReRun(getContext());
 						getActivity().finish();
 					} catch (NullPointerException exception){
 						exception.printStackTrace();


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2048

Related to https://github.com/ooni/probe/issues/1709

## Proposed Changes

  - Delete Log file immediately test is re-run and not before.