### PR TITLE
chore: use ooni/probe-cli v3.15.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'org.openobservatory.ooniprobe'
 }
 
 dependencies {

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="org.openobservatory.ooniprobe">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<!-- Allows unlocking your device and activating its screen so UI tests can succeed -->
 	<uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="org.openobservatory.ooniprobe">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<!-- Allows unlocking your device and activating its screen so UI tests can succeed -->
 	<uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>

--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:tools="http://schemas.android.com/tools"
-	package="org.openobservatory.ooniprobe">
+	xmlns:tools="http://schemas.android.com/tools">
 
 	<uses-permission android:name="${applicationId}.CountlyPush.BROADCAST_PERMISSION" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="org.openobservatory.ooniprobe">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
@@ -61,7 +61,8 @@ public class OverviewActivity extends AbstractActivity {
 			String experimentalLinks =
 					"\n\n* [STUN Reachability](https://github.com/ooni/spec/blob/master/nettests/ts-025-stun-reachability.md)" +
 					"\n\n* [DNS Check](https://github.com/ooni/spec/blob/master/nettests/ts-028-dnscheck.md)" +
-					"\n\n* [Tor Snowflake](https://ooni.org/nettest/tor-snowflake/)";
+					"\n\n* [Tor Snowflake](https://ooni.org/nettest/tor-snowflake/)" +
+					"\n\n* [Vanilla Tor](https://github.com/ooni/spec/blob/master/nettests/ts-016-vanilla-tor.md)";
 			Markwon.setMarkdown(desc, getString(testSuite.getDesc1(), experimentalLinks));
 		}
 		else

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/service/ServiceUtil.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/service/ServiceUtil.java
@@ -15,9 +15,9 @@ import org.openobservatory.ooniprobe.common.Application;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ReachabilityManager;
 import org.openobservatory.ooniprobe.domain.GenerateAutoRunServiceSuite;
-import org.openobservatory.ooniprobe.test.TestAsyncTask;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
 import org.openobservatory.ooniprobe.test.suite.CircumventionSuite;
+import org.openobservatory.ooniprobe.test.suite.ExperimentalSuite;
 import org.openobservatory.ooniprobe.test.suite.InstantMessagingSuite;
 
 import java.util.ArrayList;
@@ -94,6 +94,7 @@ public class ServiceUtil {
         testSuites.add(suite);
         testSuites.add(new InstantMessagingSuite());
         testSuites.add(new CircumventionSuite());
+        testSuites.add(ExperimentalSuite.initForAutoRun());
 
         if (suite != null) {
             Intent serviceIntent = new Intent(app, RunTestService.class);

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/ExperimentalSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/ExperimentalSuite.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 
 public class ExperimentalSuite extends AbstractSuite {
     public static final String NAME = "experimental";
+    private boolean autoRun;
 
     public ExperimentalSuite() {
         super(NAME,
@@ -26,14 +27,33 @@ public class ExperimentalSuite extends AbstractSuite {
                 R.string.TestResults_NotAvailable);
     }
 
-    @Override public AbstractTest[] getTestList(@Nullable PreferenceManager pm) {
+    public static ExperimentalSuite initForAutoRun() {
+        ExperimentalSuite suite = new ExperimentalSuite();
+        suite.setAutoRun(true);
+        return suite;
+    }
+
+
+    @Override
+    public AbstractTest[] getTestList(@Nullable PreferenceManager pm) {
         if (super.getTestList(pm) == null) {
             ArrayList<AbstractTest> list = new ArrayList<>();
+            if (getAutoRun()) {
+                list.add(new Experimental("torsf"));
+                list.add(new Experimental("vanilla_tor"));
+            }
             list.add(new Experimental("stunreachability"));
             list.add(new Experimental("dnscheck"));
-            list.add(new Experimental("torsf"));
-            list.add(new Experimental("vanilla_tor"));
             super.setTestList(list.toArray(new AbstractTest[0]));
         }
         return super.getTestList(pm);
-    }}
+    }
+
+    public boolean getAutoRun() {
+        return autoRun;
+    }
+
+    public void setAutoRun(boolean autoRun) {
+        this.autoRun = autoRun;
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/ExperimentalSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/ExperimentalSuite.java
@@ -32,6 +32,7 @@ public class ExperimentalSuite extends AbstractSuite {
             list.add(new Experimental("stunreachability"));
             list.add(new Experimental("dnscheck"));
             list.add(new Experimental("torsf"));
+            list.add(new Experimental("vanilla_tor"));
             super.setTestList(list.toArray(new AbstractTest[0]));
         }
         return super.getTestList(pm);

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		maven { url "https://jitpack.io" }
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.0.3'
+		classpath 'com.android.tools.build:gradle:7.2.0'
 		classpath 'com.google.gms:google-services:4.3.10'
 	}
 }

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -32,8 +32,8 @@ android {
 dependencies {
     // For the stable and dev app flavours we're using the library
     // build published at Maven Central.
-    stableImplementation 'org.ooni:oonimkall:2022.05.23-164657'
-    devImplementation 'org.ooni:oonimkall:2022.05.23-164657'
+    stableImplementation 'org.ooni:oonimkall:2022.06.07-100856'
+    devImplementation 'org.ooni:oonimkall:2022.06.07-100856'
 
     // For the experimental flavour, you need to compile your own
     // oonimkall.aar and put it into the ../engine-experimental dir

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -31,8 +31,8 @@ android {
 dependencies {
     // For the stable and dev app flavours we're using the library
     // build published at Maven Central.
-    stableImplementation 'org.ooni:oonimkall:2022.02.23-152335'
-    devImplementation 'org.ooni:oonimkall:2022.02.23-152335'
+    stableImplementation 'org.ooni:oonimkall:2022.05.23-164657'
+    devImplementation 'org.ooni:oonimkall:2022.05.23-164657'
 
     // For the experimental flavour, you need to compile your own
     // oonimkall.aar and put it into the ../engine-experimental dir

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -26,6 +26,7 @@ android {
             dimension 'testing'
         }
     }
+    namespace 'org.openobservatory.engine'
 }
 
 dependencies {

--- a/engine/src/main/AndroidManifest.xml
+++ b/engine/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.openobservatory.engine" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request starts adding support for ooni/probe-cli v3.15.1.

See https://github.com/ooni/probe/issues/2100

While there, upgrade gradle and apply recommended settings.