### PR TITLE
Wrong ASN displayed in successful results of a re-run failed test when different network is selected

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -205,36 +205,26 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
             }
         }
         assert detail != null && head != null;
-        if (measurement.rerun_network!=null && !measurement.rerun_network.isEmpty()){
+        var net = measurement.result.network;
+        var cc = measurement.result.network.country_code;
+        if (measurement.rerun_network != null && !measurement.rerun_network.isEmpty()) {
             Network network = new Gson().fromJson(measurement.rerun_network,Network.class);
-            getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.footer, ResultHeaderDetailFragment.newInstance(
-                            true,
-                            null,
-                            null,
-                            measurement.start_time,
-                            measurement.runtime,
-                            false,
-                            network.country_code,
-                            network))
-                    .replace(R.id.body, detail)
-                    .replace(R.id.head, head)
-                    .commit();
-        }else {
-            getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.footer, ResultHeaderDetailFragment.newInstance(
-                            true,
-                            null,
-                            null,
-                            measurement.start_time,
-                            measurement.runtime,
-                            false,
-                            measurement.result.network.country_code,
-                            measurement.result.network))
-                    .replace(R.id.body, detail)
-                    .replace(R.id.head, head)
-                    .commit();
+            net = network;
+            cc = network.country_code;
         }
+        getSupportFragmentManager().beginTransaction()
+                .replace(R.id.footer, ResultHeaderDetailFragment.newInstance(
+                       true,
+                       null,
+                       null,
+                       measurement.start_time,
+                       measurement.runtime,
+                       false,
+                       cc,
+                       net))
+                .replace(R.id.body, detail)
+                .replace(R.id.head, head)
+                .commit();
         snackbar = Snackbar.make(coordinatorLayout, R.string.Snackbar_ResultsNotUploaded_Text, Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.Snackbar_ResultsNotUploaded_Upload, v1 -> runAsyncTask());
         Context c = this;

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -18,6 +18,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.google.gson.Gson;
 
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
@@ -41,6 +42,7 @@ import org.openobservatory.ooniprobe.fragment.measurement.WebConnectivityFragmen
 import org.openobservatory.ooniprobe.fragment.measurement.WhatsappFragment;
 import org.openobservatory.ooniprobe.fragment.resultHeader.ResultHeaderDetailFragment;
 import org.openobservatory.ooniprobe.model.database.Measurement;
+import org.openobservatory.ooniprobe.model.database.Network;
 import org.openobservatory.ooniprobe.test.suite.PerformanceSuite;
 import org.openobservatory.ooniprobe.test.test.Dash;
 import org.openobservatory.ooniprobe.test.test.FacebookMessenger;
@@ -203,19 +205,36 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
             }
         }
         assert detail != null && head != null;
-        getSupportFragmentManager().beginTransaction()
-                .replace(R.id.footer, ResultHeaderDetailFragment.newInstance(
-                        true,
-                        null,
-                        null,
-                        measurement.start_time,
-                        measurement.runtime,
-                        false,
-                        measurement.result.network.country_code,
-                        measurement.result.network))
-                .replace(R.id.body, detail)
-                .replace(R.id.head, head)
-                .commit();
+        if (measurement.rerun_network!=null && !measurement.rerun_network.isEmpty()){
+            Network network = new Gson().fromJson(measurement.rerun_network,Network.class);
+            getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.footer, ResultHeaderDetailFragment.newInstance(
+                            true,
+                            null,
+                            null,
+                            measurement.start_time,
+                            measurement.runtime,
+                            false,
+                            network.country_code,
+                            network))
+                    .replace(R.id.body, detail)
+                    .replace(R.id.head, head)
+                    .commit();
+        }else {
+            getSupportFragmentManager().beginTransaction()
+                    .replace(R.id.footer, ResultHeaderDetailFragment.newInstance(
+                            true,
+                            null,
+                            null,
+                            measurement.start_time,
+                            measurement.runtime,
+                            false,
+                            measurement.result.network.country_code,
+                            measurement.result.network))
+                    .replace(R.id.body, detail)
+                    .replace(R.id.head, head)
+                    .commit();
+        }
         snackbar = Snackbar.make(coordinatorLayout, R.string.Snackbar_ResultsNotUploaded_Text, Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.Snackbar_ResultsNotUploaded_Upload, v1 -> runAsyncTask());
         Context c = this;

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/AppDatabase.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/AppDatabase.java
@@ -5,12 +5,13 @@ import com.raizlabs.android.dbflow.annotation.Migration;
 import com.raizlabs.android.dbflow.sql.SQLiteType;
 import com.raizlabs.android.dbflow.sql.migration.AlterTableMigration;
 
+import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.database.Result;
 
 @Database(name = AppDatabase.NAME, version = AppDatabase.VERSION, foreignKeyConstraintsEnforced = true)
 public class AppDatabase {
     public static final String NAME = "v2";
-    public static final int VERSION = 2;
+    public static final int VERSION = 3;
 
     @Migration(version = 2, database = AppDatabase.class)
     public static class Migration2 extends AlterTableMigration<Result> {
@@ -22,6 +23,20 @@ public class AppDatabase {
         @Override
         public void onPreMigrate() {
             addColumn(SQLiteType.TEXT, "failure_msg");
+        }
+
+    }
+
+    @Migration(version = 3, database = AppDatabase.class)
+    public static class Migration3 extends AlterTableMigration<Measurement> {
+
+        public Migration3(Class<Measurement> table) {
+            super(table);
+        }
+
+        @Override
+        public void onPreMigrate() {
+            addColumn(SQLiteType.TEXT, "rerun_network");
         }
 
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/FailedFragment.java
@@ -49,6 +49,7 @@ public class FailedFragment extends Fragment {
 		assert failedMeasurement != null;
 		failedMeasurement.result.load();
 		AbstractTest abstractTest = failedMeasurement.getTest();
+		abstractTest.setIsRerun(true);
 		if (failedMeasurement.url != null)
 			abstractTest.setInputs(Collections.singletonList(failedMeasurement.url.url));
 		AbstractSuite testSuite = failedMeasurement.result.getTestSuite();

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
@@ -55,6 +55,7 @@ public class Measurement extends BaseModel implements Serializable {
 	@Column public boolean is_upload_failed;
 	@Column public String upload_failure_msg;
 	@Column public boolean is_rerun;
+	@Column public String rerun_network;
 	@Column public String report_id;
 	@Column public boolean is_anomaly;
 	@Column public String test_keys;

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -109,7 +109,7 @@ public abstract class AbstractTest implements Serializable {
                         testCallback.onProgress(Double.valueOf(index * 100).intValue());
                         break;
                     case "status.geoip_lookup":
-                        if (is_rerun){
+                        if (is_rerun) {
                             this.network = new Network();
                             network.network_name = event.value.probe_network_name;
                             network.asn = event.value.probe_asn;

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -46,6 +46,13 @@ public abstract class AbstractTest implements Serializable {
     private final int runtime;
     private List<String> inputs;
     private Integer max_runtime;
+    private Network network;
+
+    public void setIsRerun(boolean is_rerun) {
+        this.is_rerun = is_rerun;
+    }
+
+    private boolean is_rerun;
     private SparseArray<Measurement> measurements;
     private String reportId;
     private String origin;
@@ -102,6 +109,16 @@ public abstract class AbstractTest implements Serializable {
                         testCallback.onProgress(Double.valueOf(index * 100).intValue());
                         break;
                     case "status.geoip_lookup":
+                        if (is_rerun){
+                            this.network = new Network();
+                            network.network_name = event.value.probe_network_name;
+                            network.asn = event.value.probe_asn;
+                            network.ip = event.value.probe_ip;
+                            network.country_code = event.value.probe_cc;
+                            network.network_type = ReachabilityManager.getNetworkType(c);
+                        }else {
+                            this.network=null;
+                        }
                         saveNetworkInfo(event.value, result, c);
                         break;
                     case "status.report_create":
@@ -145,6 +162,9 @@ public abstract class AbstractTest implements Serializable {
                                 m.is_failed = true;
                             else
                                 onEntry(c, pm, jr, m);
+                            if (network!=null){
+                                m.rerun_network = gson.toJson(network);
+                            }
                             m.save();
                             File entryFile = Measurement.getEntryFile(c, m.id, m.test_name);
                             entryFile.getParentFile().mkdirs();

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -162,7 +162,7 @@ public abstract class AbstractTest implements Serializable {
                                 m.is_failed = true;
                             else
                                 onEntry(c, pm, jr, m);
-                            if (network!=null){
+                            if (network!=null ){
                                 m.rerun_network = gson.toJson(network);
                             }
                             m.save();

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -116,7 +116,7 @@ public abstract class AbstractTest implements Serializable {
                             network.ip = event.value.probe_ip;
                             network.country_code = event.value.probe_cc;
                             network.network_type = ReachabilityManager.getNetworkType(c);
-                        }else {
+                        } else {
                             this.network=null;
                         }
                         saveNetworkInfo(event.value, result, c);


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/851

## Proposed Changes

  -  Update `Measurement`  table to add  `rerun_network` column.
  - Annotate  `AbstractTest` before rerun is triggered.
  - Capture network during `status.geoip_lookup` event and save to class instance.
  - Update measurement to include new network during `measurement` probe-enigine evennt