### PR TITLE
Fix: `RunningActivity` back button

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
@@ -239,11 +239,6 @@ public class RunningActivity extends AbstractActivity implements ConfirmDialogFr
         LocalBroadcastManager.getInstance(this).unregisterReceiver(receiver);
     }
 
-    @Override
-    public void onBackPressed() {
-        Toast.makeText(this, getString(R.string.Modal_Error_CantCloseScreen), Toast.LENGTH_SHORT).show();
-    }
-
     private void testEnded(Context context) {
         startActivity(MainActivity.newIntent(context, R.id.testResults));
         finish();


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2156
## Proposed Changes

  - Remove code path blocking activity exit and ensure test is still running.