### PR TITLE
Feat: append `-unattended` to software_name used for unattended runs

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/service/ServiceUtil.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/service/ServiceUtil.java
@@ -92,14 +92,14 @@ public class ServiceUtil {
         AbstractSuite suite = d.generateAutoRunServiceSuite.generate(config);
         ArrayList<AbstractSuite> testSuites = new ArrayList<>();
         testSuites.add(suite);
-        testSuites.add(new InstantMessagingSuite());
-        testSuites.add(new CircumventionSuite());
+        testSuites.add(InstantMessagingSuite.initForAutoRun());
+        testSuites.add(CircumventionSuite.initForAutoRun());
         testSuites.add(ExperimentalSuite.initForAutoRun());
 
         if (suite != null) {
             Intent serviceIntent = new Intent(app, RunTestService.class);
             serviceIntent.putExtra("testSuites", testSuites);
-            serviceIntent.putExtra("storeDB", false);
+            serviceIntent.putExtra("storeDB", true);
             ContextCompat.startForegroundService(app, serviceIntent);
         }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/service/ServiceUtil.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/service/ServiceUtil.java
@@ -99,7 +99,7 @@ public class ServiceUtil {
         if (suite != null) {
             Intent serviceIntent = new Intent(app, RunTestService.class);
             serviceIntent.putExtra("testSuites", testSuites);
-            serviceIntent.putExtra("storeDB", true);
+            serviceIntent.putExtra("storeDB", false);
             ContextCompat.startForegroundService(app, serviceIntent);
         }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/GenerateAutoRunServiceSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/GenerateAutoRunServiceSuite.java
@@ -13,6 +13,7 @@ import org.openobservatory.ooniprobe.common.ReachabilityManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.test.EngineProvider;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
+import org.openobservatory.ooniprobe.test.test.AbstractTest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +39,7 @@ public class GenerateAutoRunServiceSuite {
             OONISession session = EngineProvider.get().newSession(
                     EngineProvider.get().getDefaultSessionConfig(
                             app,
-                            BuildConfig.SOFTWARE_NAME,
+                            BuildConfig.SOFTWARE_NAME + "-unattended",
                             BuildConfig.VERSION_NAME,
                             new LoggerArray(),
                             pm.getProxyURL()
@@ -61,7 +62,7 @@ public class GenerateAutoRunServiceSuite {
                         app,
                         "web_connectivity",
                         inputs,
-                        "autorun"
+                        AbstractTest.AUTORUN
                 );
             }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/GenerateAutoRunServiceSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/GenerateAutoRunServiceSuite.java
@@ -39,7 +39,7 @@ public class GenerateAutoRunServiceSuite {
             OONISession session = EngineProvider.get().newSession(
                     EngineProvider.get().getDefaultSessionConfig(
                             app,
-                            BuildConfig.SOFTWARE_NAME + "-unattended",
+                            String.join("-",BuildConfig.SOFTWARE_NAME, AbstractTest.UNATTENDED),
                             BuildConfig.VERSION_NAME,
                             new LoggerArray(),
                             pm.getProxyURL()

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/settings/Settings.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/settings/Settings.java
@@ -10,6 +10,7 @@ import org.openobservatory.ooniprobe.BuildConfig;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ReachabilityManager;
 import org.openobservatory.ooniprobe.test.EngineProvider;
+import org.openobservatory.ooniprobe.test.test.AbstractTest;
 
 import java.util.Arrays;
 import java.util.List;
@@ -122,7 +123,7 @@ public class Settings {
 
         public Options(PreferenceManager pm, boolean isAutoRun) {
             no_collector = !pm.isUploadResults();
-            software_name = BuildConfig.SOFTWARE_NAME + (isAutoRun ? "-unattended" : "");
+            software_name = BuildConfig.SOFTWARE_NAME + (isAutoRun ? "-"+AbstractTest.UNATTENDED : "");
             software_version = BuildConfig.VERSION_NAME;
         }
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/settings/Settings.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/settings/Settings.java
@@ -51,14 +51,14 @@ public class Settings {
 	@SerializedName("version")
 	private Integer version;
 
-	public Settings(Context c, PreferenceManager pm) {
-		annotations = new Annotations(c);
-		disabled_events = Arrays.asList("status.queued", "status.update.websites", "failure.report_close");
-		log_level = pm.isDebugLogs() ? "DEBUG2" : "INFO";
-		version = 1;
-		options = new Options(pm);
-		proxy = pm.getProxyURL();
-	}
+    public Settings(Context c, PreferenceManager pm, boolean isAutoRun) {
+        annotations = new Annotations(c);
+        disabled_events = Arrays.asList("status.queued", "status.update.websites", "failure.report_close");
+        log_level = pm.isDebugLogs() ? "DEBUG2" : "INFO";
+        version = 1;
+        options = new Options(pm, isAutoRun);
+        proxy = pm.getProxyURL();
+    }
 
 	public OONIMKTaskConfig toExperimentSettings(Gson gson, Context c) throws java.io.IOException {
 		assets_dir = EngineProvider.get().getAssetsDir(c);
@@ -120,10 +120,10 @@ public class Settings {
 		@SerializedName("probe_services_base_url")
 		public String probe_services_base_url;
 
-		public Options(PreferenceManager pm) {
-			no_collector = !pm.isUploadResults();
-			software_name = BuildConfig.SOFTWARE_NAME;
-			software_version = BuildConfig.VERSION_NAME;
-		}
-	}
+        public Options(PreferenceManager pm, boolean isAutoRun) {
+            no_collector = !pm.isUploadResults();
+            software_name = BuildConfig.SOFTWARE_NAME + (isAutoRun ? "-unattended" : "");
+            software_version = BuildConfig.VERSION_NAME;
+        }
+    }
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/receiver/TestRunBroadRequestReceiver.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/receiver/TestRunBroadRequestReceiver.java
@@ -56,7 +56,7 @@ public class TestRunBroadRequestReceiver extends BroadcastReceiver implements Se
                 listener.onRun(value);
                 break;
             case TestAsyncTask.PRG:
-                if (service != null) {
+                if (service != null && service.task.testSuites.indexOf(service.task.currentSuite) > 0) {
                     List<AbstractSuite> previousTestSuites =
                             service.task.testSuites.subList(0, service.task.testSuites.indexOf(service.task.currentSuite));
                     int previousTestProgress = (int) Stats.of(Lists.transform(

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/AbstractSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/AbstractSuite.java
@@ -34,6 +34,7 @@ public abstract class AbstractSuite implements Serializable {
 	private final int dataUsage;
 	private AbstractTest[] testList;
 	private Result result;
+	private boolean autoRun;
 
 	AbstractSuite(String name, @StringRes int title, @StringRes int cardDesc, @DrawableRes int icon, @DrawableRes int icon_24, @ColorRes int color, @StyleRes int themeLight, @StyleRes int themeDark, @StringRes int desc1, String anim, int dataUsage) {
 		this.title = title;
@@ -130,6 +131,14 @@ public abstract class AbstractSuite implements Serializable {
 		ArrayList<AbstractSuite> list = new ArrayList<>();
 		list.add(this);
 		return list;
+	}
+
+	public boolean getAutoRun() {
+		return autoRun;
+	}
+
+	public void setAutoRun(boolean autoRun) {
+		this.autoRun = autoRun;
 	}
 
 	public static AbstractSuite getSuite(Application app,

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/CircumventionSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/CircumventionSuite.java
@@ -2,11 +2,12 @@ package org.openobservatory.ooniprobe.test.suite;
 
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.Lists;
+
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.test.test.AbstractTest;
 import org.openobservatory.ooniprobe.test.test.Psiphon;
-import org.openobservatory.ooniprobe.test.test.RiseupVPN;
 import org.openobservatory.ooniprobe.test.test.Tor;
 
 import java.util.ArrayList;
@@ -28,6 +29,13 @@ public class CircumventionSuite extends AbstractSuite {
                 R.string.small_datausage);
     }
 
+
+    public static CircumventionSuite initForAutoRun() {
+        CircumventionSuite suite = new CircumventionSuite();
+        suite.setAutoRun(true);
+        return suite;
+    }
+
     @Override public AbstractTest[] getTestList(@Nullable PreferenceManager pm) {
         if (super.getTestList(pm) == null) {
             ArrayList<AbstractTest> list = new ArrayList<>();
@@ -40,7 +48,10 @@ public class CircumventionSuite extends AbstractSuite {
                 To be enabled only when test is fixed or removed if deemed necessary.
                 if (pm == null || pm.isTestRiseupVPN())
                 list.add(new RiseupVPN());*/
-            super.setTestList(list.toArray(new AbstractTest[0]));
+            super.setTestList(Lists.transform(list, test -> {
+                if (getAutoRun()) test.setOrigin(AbstractTest.AUTORUN);
+                return test;
+            }).toArray(new AbstractTest[0]));
         }
         return super.getTestList(pm);
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/ExperimentalSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/ExperimentalSuite.java
@@ -2,6 +2,8 @@ package org.openobservatory.ooniprobe.test.suite;
 
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.Lists;
+
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.test.test.AbstractTest;
@@ -11,7 +13,6 @@ import java.util.ArrayList;
 
 public class ExperimentalSuite extends AbstractSuite {
     public static final String NAME = "experimental";
-    private boolean autoRun;
 
     public ExperimentalSuite() {
         super(NAME,
@@ -44,16 +45,12 @@ public class ExperimentalSuite extends AbstractSuite {
             }
             list.add(new Experimental("stunreachability"));
             list.add(new Experimental("dnscheck"));
-            super.setTestList(list.toArray(new AbstractTest[0]));
+            super.setTestList(Lists.transform(list, test->{
+                if (getAutoRun()) test.setOrigin(AbstractTest.AUTORUN);
+                return test;
+            }).toArray(new AbstractTest[0]));
         }
         return super.getTestList(pm);
     }
 
-    public boolean getAutoRun() {
-        return autoRun;
-    }
-
-    public void setAutoRun(boolean autoRun) {
-        this.autoRun = autoRun;
-    }
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/InstantMessagingSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/InstantMessagingSuite.java
@@ -2,6 +2,8 @@ package org.openobservatory.ooniprobe.test.suite;
 
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.Lists;
+
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.test.test.AbstractTest;
@@ -29,6 +31,12 @@ public class InstantMessagingSuite extends AbstractSuite {
 				R.string.small_datausage);
 	}
 
+	public static InstantMessagingSuite initForAutoRun() {
+		InstantMessagingSuite suite = new InstantMessagingSuite();
+		suite.setAutoRun(true);
+		return suite;
+	}
+
 	@Override public AbstractTest[] getTestList(@Nullable PreferenceManager pm) {
 		if (super.getTestList(pm) == null) {
 			ArrayList<AbstractTest> list = new ArrayList<>();
@@ -40,7 +48,10 @@ public class InstantMessagingSuite extends AbstractSuite {
 				list.add(new FacebookMessenger());
 			if (pm == null || pm.isTestSignal())
 				list.add(new Signal());
-			super.setTestList(list.toArray(new AbstractTest[0]));
+			super.setTestList(Lists.transform(list, test->{
+				if (getAutoRun()) test.setOrigin(AbstractTest.AUTORUN);
+				return test;
+			}).toArray(new AbstractTest[0]));
 		}
 		return super.getTestList(pm);
 	}

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/MiddleBoxesSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/MiddleBoxesSuite.java
@@ -2,6 +2,8 @@ package org.openobservatory.ooniprobe.test.suite;
 
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.Lists;
+
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.test.test.AbstractTest;
@@ -41,7 +43,10 @@ public class MiddleBoxesSuite extends AbstractSuite {
 				list.add(new HttpHeaderFieldManipulation());
 			if (pm == null || pm.isRunHttpInvalidRequestLine())
 				list.add(new HttpInvalidRequestLine());
-			super.setTestList(list.toArray(new AbstractTest[0]));
+			super.setTestList(Lists.transform(list, test->{
+				if (getAutoRun()) test.setOrigin(AbstractTest.AUTORUN);
+				return test;
+			}).toArray(new AbstractTest[0]));
 		}
 		return super.getTestList(pm);
 	}

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/PerformanceSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/PerformanceSuite.java
@@ -2,6 +2,8 @@ package org.openobservatory.ooniprobe.test.suite;
 
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.Lists;
+
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.test.test.AbstractTest;
@@ -40,7 +42,10 @@ public class PerformanceSuite extends AbstractSuite {
 				list.add(new HttpHeaderFieldManipulation());
 			if (pm == null || pm.isRunHttpInvalidRequestLine())
 				list.add(new HttpInvalidRequestLine());
-			super.setTestList(list.toArray(new AbstractTest[0]));
+			super.setTestList(Lists.transform(list, test->{
+				if (getAutoRun()) test.setOrigin(AbstractTest.AUTORUN);
+				return test;
+			}).toArray(new AbstractTest[0]));
 		}
 		return super.getTestList(pm);
 	}

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/WebsitesSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/WebsitesSuite.java
@@ -25,8 +25,11 @@ public class WebsitesSuite extends AbstractSuite {
 	}
 
 	@Override public AbstractTest[] getTestList(@Nullable PreferenceManager pm) {
-		if (super.getTestList(pm) == null)
-			super.setTestList(new WebConnectivity());
+		if (super.getTestList(pm) == null){
+			WebConnectivity test = new WebConnectivity();
+			if (getAutoRun()) test.setOrigin(AbstractTest.AUTORUN);
+			super.setTestList(test);
+		}
 		return super.getTestList(pm);
 	}
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -41,6 +41,7 @@ public abstract class AbstractTest implements Serializable {
     private static final String UNUSED_KEY = "UNUSED_KEY";
     private static final String TAG = "MK_EVENT";
     public static final String AUTORUN = "autorun";
+    public static final String UNATTENDED = "unattended";
     private final String name;
     private final int labelResId;
     private final int iconResId;

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -35,10 +35,12 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 
 public abstract class AbstractTest implements Serializable {
     private static final String UNUSED_KEY = "UNUSED_KEY";
     private static final String TAG = "MK_EVENT";
+    public static final String AUTORUN = "autorun";
     private final String name;
     private final int labelResId;
     private final int iconResId;
@@ -331,6 +333,10 @@ public abstract class AbstractTest implements Serializable {
 
     public void setOrigin(String origin) {
         this.origin = origin;
+    }
+
+    public boolean isAutoRun() {
+        return Objects.equals(origin, AUTORUN);
     }
 
     public interface TestCallback {

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/Dash.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/Dash.java
@@ -21,7 +21,7 @@ public class Dash extends AbstractTest {
 	}
 
 	@Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, TestCallback testCallback) {
-		Settings settings = new Settings(c, pm);
+		Settings settings = new Settings(c, pm, isAutoRun());
 		run(c, pm, gson, settings, result, index, testCallback);
 	}
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/Experimental.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/Experimental.java
@@ -22,7 +22,7 @@ public class Experimental extends AbstractTest {
     }
 
     @Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, AbstractTest.TestCallback testCallback) {
-        Settings settings = new Settings(c, pm);
+        Settings settings = new Settings(c, pm, isAutoRun());
         run(c, pm, gson, settings, result, index, testCallback);
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/FacebookMessenger.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/FacebookMessenger.java
@@ -21,7 +21,7 @@ public class FacebookMessenger extends AbstractTest {
 	}
 
 	@Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, TestCallback testCallback) {
-		Settings settings = new Settings(c, pm);
+		Settings settings = new Settings(c, pm, isAutoRun());
 		run(c, pm, gson, settings, result, index, testCallback);
 	}
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/HttpHeaderFieldManipulation.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/HttpHeaderFieldManipulation.java
@@ -21,7 +21,7 @@ public class HttpHeaderFieldManipulation extends AbstractTest {
 	}
 
 	@Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, TestCallback testCallback) {
-		Settings settings = new Settings(c, pm);
+		Settings settings = new Settings(c, pm, isAutoRun());
 		run(c, pm, gson, settings, result, index, testCallback);
 	}
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/HttpInvalidRequestLine.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/HttpInvalidRequestLine.java
@@ -21,7 +21,7 @@ public class HttpInvalidRequestLine extends AbstractTest {
 	}
 
 	@Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, TestCallback testCallback) {
-		Settings settings = new Settings(c, pm);
+		Settings settings = new Settings(c, pm, isAutoRun());
 		run(c, pm, gson, settings, result, index, testCallback);
 	}
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/Ndt.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/Ndt.java
@@ -24,7 +24,7 @@ public class Ndt extends AbstractTest {
 
 	@Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, TestCallback testCallback) {
 		countries = c.getResources().getStringArray(R.array.countries);
-		Settings settings = new Settings(c, pm);
+		Settings settings = new Settings(c, pm, isAutoRun());
 		run(c, pm, gson, settings, result, index, testCallback);
 	}
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/Psiphon.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/Psiphon.java
@@ -21,7 +21,7 @@ public class Psiphon extends AbstractTest {
     }
 
     @Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, AbstractTest.TestCallback testCallback) {
-        Settings settings = new Settings(c, pm);
+        Settings settings = new Settings(c, pm, isAutoRun());
         run(c, pm, gson, settings, result, index, testCallback);
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/RiseupVPN.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/RiseupVPN.java
@@ -16,8 +16,6 @@ import org.openobservatory.ooniprobe.model.database.Result;
 import org.openobservatory.ooniprobe.model.jsonresult.JsonResult;
 import org.openobservatory.ooniprobe.model.settings.Settings;
 
-import java.util.HashMap;
-
 public class RiseupVPN extends AbstractTest {
     public static final String NAME = "riseupvpn";
 
@@ -26,7 +24,7 @@ public class RiseupVPN extends AbstractTest {
     }
 
     @Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, AbstractTest.TestCallback testCallback) {
-        Settings settings = new Settings(c, pm);
+        Settings settings = new Settings(c, pm, isAutoRun());
         run(c, pm, gson, settings, result, index, testCallback);
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/Signal.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/Signal.java
@@ -23,7 +23,7 @@ public class Signal extends AbstractTest {
     }
 
     @Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, AbstractTest.TestCallback testCallback) {
-        Settings settings = new Settings(c, pm);
+        Settings settings = new Settings(c, pm, isAutoRun());
         run(c, pm, gson, settings, result, index, testCallback);
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/Telegram.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/Telegram.java
@@ -23,7 +23,7 @@ public class Telegram extends AbstractTest {
 	}
 
 	@Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, TestCallback testCallback) {
-		Settings settings = new Settings(c, pm);
+		Settings settings = new Settings(c, pm, isAutoRun());
 		run(c, pm, gson, settings, result, index, testCallback);
 	}
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/Tor.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/Tor.java
@@ -21,7 +21,7 @@ public class Tor extends AbstractTest {
     }
 
     @Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, AbstractTest.TestCallback testCallback) {
-        Settings settings = new Settings(c, pm);
+        Settings settings = new Settings(c, pm, isAutoRun());
         run(c, pm, gson, settings, result, index, testCallback);
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/WebConnectivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/WebConnectivity.java
@@ -23,7 +23,7 @@ public class WebConnectivity extends AbstractTest {
 	}
 
 	@Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, TestCallback testCallback) {
-		Settings settings = new Settings(c, pm);
+		Settings settings = new Settings(c, pm, isAutoRun());
 
 		ThirdPartyServices.addLogExtra("_settings", ((Application) c.getApplicationContext()).getGson().toJson(settings));
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/Whatsapp.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/Whatsapp.java
@@ -23,7 +23,7 @@ public class Whatsapp extends AbstractTest {
 	}
 
 	@Override public void run(Context c, PreferenceManager pm, Gson gson, Result result, int index, TestCallback testCallback) {
-		Settings settings = new Settings(c, pm);
+		Settings settings = new Settings(c, pm, isAutoRun());
 		run(c, pm, gson, settings, result, index, testCallback);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2167

## Proposed Changes

  - Update `AbstractSuite` to include `boolean autoRun`
  - Update `getTestList` to set origin of tests to `autorun` when appropriate.
  - Pass `isAutoRun` to `AbstractTest` settings when `AbstractTest.run` and use that to update `Settings.Options` appropriately.
