### PR TITLE
chore: use ooni/probe-cli@v3.15.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ dependencies {
 	testImplementation 'org.mockito:mockito-inline:3.10.0'
 	testImplementation 'org.robolectric:robolectric:4.5.1'
 	testImplementation 'com.github.blocoio:faker:1.2.8'
-	testImplementation 'org.ooni:oonimkall:2021.05.13-070256'
+	testImplementation 'org.ooni:oonimkall:2022.07.04-102558'
 	testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.36'
 
 	// Instrumentation Testing

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -32,8 +32,8 @@ android {
 dependencies {
     // For the stable and dev app flavours we're using the library
     // build published at Maven Central.
-    stableImplementation 'org.ooni:oonimkall:2022.06.07-100856'
-    devImplementation 'org.ooni:oonimkall:2022.06.07-100856'
+    stableImplementation 'org.ooni:oonimkall:2022.07.04-102558'
+    devImplementation 'org.ooni:oonimkall:2022.07.04-102558'
 
     // For the experimental flavour, you need to compile your own
     // oonimkall.aar and put it into the ../engine-experimental dir


### PR DESCRIPTION
This release updates dependencies and fixes a crash on mobile
devices: https://github.com/ooni/probe/issues/2173.
