### PR TITLE
update measurement-log retention policy

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -48,9 +48,7 @@ public class Application extends android.app.Application {
 			FlowLog.setMinimumLoggingLevel(FlowLog.Level.V);
 		AppLifecycleObserver appLifecycleObserver = new AppLifecycleObserver();
 		ProcessLifecycleOwner.get().getLifecycle().addObserver(appLifecycleObserver);
-		if (_preferenceManager.canCallDeleteJson())
-			Measurement.deleteUploadedJsons(this);
-		Measurement.deleteOldLogs(this);
+
 		ThirdPartyServices.reloadConsents(this);
 
 		LocaleUtils.setLocale(new Locale(_preferenceManager.getSettingsLanguage()));

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -48,7 +48,7 @@ public class Application extends android.app.Application {
 			FlowLog.setMinimumLoggingLevel(FlowLog.Level.V);
 		AppLifecycleObserver appLifecycleObserver = new AppLifecycleObserver();
 		ProcessLifecycleOwner.get().getLifecycle().addObserver(appLifecycleObserver);
-
+		Measurement.deleteOldLogs(this);
 		ThirdPartyServices.reloadConsents(this);
 
 		LocaleUtils.setLocale(new Locale(_preferenceManager.getSettingsLanguage()));

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
@@ -154,6 +154,9 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
                 m.result.load();
                 if(!d.measurementsManager.reSubmit(m, session)){
                     errors++;
+                }else {
+                    m.deleteEntryFile(getActivity());
+                    m.deleteLogFile(getActivity());
                 }
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
@@ -79,7 +79,6 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
             FileUtils.writeStringToFile(file, results.getUpdatedMeasurement(), StandardCharsets.UTF_8);
             m.report_id = results.getUpdatedReportID();
             m.deleteEntryFile(c);
-            m.deleteLogFile(c);
             m.is_uploaded = true;
             m.is_upload_failed = false;
             m.save();
@@ -156,7 +155,6 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
                     errors++;
                 }else {
                     m.deleteEntryFile(getActivity());
-                    m.deleteLogFile(getActivity());
                 }
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
@@ -78,6 +78,8 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
             OONISubmitResults results = session.submit(ooniContext, input);
             FileUtils.writeStringToFile(file, results.getUpdatedMeasurement(), StandardCharsets.UTF_8);
             m.report_id = results.getUpdatedReportID();
+            m.deleteEntryFile(c);
+            m.deleteLogFile(c);
             m.is_uploaded = true;
             m.is_upload_failed = false;
             m.save();

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
@@ -69,7 +69,7 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
     }
 
     private boolean perform(Context c, Measurement m, OONISession session) {
-        File file = Measurement.getEntryFile(c, m.id, m.test_name);
+        File file = Measurement.getReportFile(c, m.id, m.test_name);
         String input;
         long uploadTimeout = getTimeout(file.length());
         OONIContext ooniContext = session.newContextWithTimeout(uploadTimeout);
@@ -78,7 +78,7 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
             OONISubmitResults results = session.submit(ooniContext, input);
             FileUtils.writeStringToFile(file, results.getUpdatedMeasurement(), StandardCharsets.UTF_8);
             m.report_id = results.getUpdatedReportID();
-            m.deleteEntryFile(c);
+            m.deleteReportFile(c);
             m.is_uploaded = true;
             m.is_upload_failed = false;
             m.save();
@@ -154,7 +154,7 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
                 if(!d.measurementsManager.reSubmit(m, session)){
                     errors++;
                 }else {
-                    m.deleteEntryFile(getActivity());
+                    m.deleteReportFile(getActivity());
                 }
             }
         }

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/MeasurementsManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/MeasurementsManager.java
@@ -7,7 +7,6 @@ import androidx.annotation.Nullable;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 
 import org.apache.commons.io.FileUtils;
-import org.jetbrains.annotations.NotNull;
 import org.openobservatory.engine.OONIContext;
 import org.openobservatory.engine.OONISession;
 import org.openobservatory.engine.OONISubmitResults;
@@ -17,7 +16,6 @@ import org.openobservatory.ooniprobe.common.JsonPrinter;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.domain.callback.DomainCallback;
 import org.openobservatory.ooniprobe.domain.callback.GetMeasurementsCallback;
-import org.openobservatory.ooniprobe.model.api.ApiMeasurement;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.database.Measurement_Table;
 
@@ -27,12 +25,7 @@ import java.nio.charset.StandardCharsets;
 
 import javax.inject.Inject;
 
-import okhttp3.Call;
-import okhttp3.Callback;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 public class MeasurementsManager {
 
@@ -106,7 +99,7 @@ public class MeasurementsManager {
     }
 
     public String getReadableEntry(Measurement measurement) throws IOException {
-        File entryFile = Measurement.getEntryFile(context, measurement.id, measurement.test_name);
+        File entryFile = Measurement.getReportFile(context, measurement.id, measurement.test_name);
         return jsonPrinter.prettyText(FileUtils.readFileToString(entryFile, StandardCharsets.UTF_8));
     }
 
@@ -126,7 +119,7 @@ public class MeasurementsManager {
     }
 
     public boolean reSubmit(Measurement m, OONISession session) {
-        File file = Measurement.getEntryFile(context, m.id, m.test_name);
+        File file = Measurement.getReportFile(context, m.id, m.test_name);
         String input;
         long uploadTimeout = getTimeout(file.length());
         OONIContext ooniContext = session.newContextWithTimeout(uploadTimeout);

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -24,6 +24,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.google.common.collect.Iterables;
 import com.raizlabs.android.dbflow.sql.language.Method;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 
@@ -45,6 +46,7 @@ import org.openobservatory.ooniprobe.item.InstantMessagingItem;
 import org.openobservatory.ooniprobe.item.MiddleboxesItem;
 import org.openobservatory.ooniprobe.item.PerformanceItem;
 import org.openobservatory.ooniprobe.item.WebsiteItem;
+import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.database.Network;
 import org.openobservatory.ooniprobe.model.database.Result;
 import org.openobservatory.ooniprobe.model.database.Result_Table;
@@ -255,9 +257,14 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
             else
                 snackbar.show();
         } else if (i == DialogInterface.BUTTON_POSITIVE) {
-            if (serializable instanceof Result)
-                ((Result) serializable).delete(getActivity());
-            else if (serializable.equals(R.id.delete)) {
+            if (serializable instanceof Result) {
+                Result result = ((Result) serializable);
+                for (Measurement measurement : result.getMeasurements()) {
+                    measurement.deleteEntryFile(getContext());
+                    measurement.deleteLogFile(getContext());
+                }
+                result.delete(getActivity());
+            } else if (serializable.equals(R.id.delete)) {
                 //From https://guides.codepath.com/android/using-dialogfragment
                 ProgressDialog pd = new ProgressDialog(getContext());
                 pd.setCancelable(false);

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ResultListFragment.java
@@ -24,7 +24,6 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.snackbar.Snackbar;
-import com.google.common.collect.Iterables;
 import com.raizlabs.android.dbflow.sql.language.Method;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 
@@ -46,7 +45,6 @@ import org.openobservatory.ooniprobe.item.InstantMessagingItem;
 import org.openobservatory.ooniprobe.item.MiddleboxesItem;
 import org.openobservatory.ooniprobe.item.PerformanceItem;
 import org.openobservatory.ooniprobe.item.WebsiteItem;
-import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.database.Network;
 import org.openobservatory.ooniprobe.model.database.Result;
 import org.openobservatory.ooniprobe.model.database.Result_Table;
@@ -258,12 +256,7 @@ public class ResultListFragment extends Fragment implements View.OnClickListener
                 snackbar.show();
         } else if (i == DialogInterface.BUTTON_POSITIVE) {
             if (serializable instanceof Result) {
-                Result result = ((Result) serializable);
-                for (Measurement measurement : result.getMeasurements()) {
-                    measurement.deleteEntryFile(getContext());
-                    measurement.deleteLogFile(getContext());
-                }
-                result.delete(getActivity());
+                ((Result) serializable).delete(getActivity());
             } else if (serializable.equals(R.id.delete)) {
                 //From https://guides.codepath.com/android/using-dialogfragment
                 ProgressDialog pd = new ProgressDialog(getContext());

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Measurement.java
@@ -159,20 +159,20 @@ public class Measurement extends BaseModel implements Serializable {
 		return measurementsLog;
 	}
 
-	public static File getEntryFile(Context c, int measurementId, String test_name) {
+	public static File getReportFile(Context c, int measurementId, String test_name) {
 		return new File(getMeasurementDir(c), measurementId + "_" + test_name + ".json");
 	}
 
-	public void deleteEntryFile(Context c){
+	public void deleteReportFile(Context c){
 		try {
-			Measurement.getEntryFile(c, this.id, this.test_name).delete();
+			Measurement.getReportFile(c, this.id, this.test_name).delete();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
 	}
 
 	public Boolean hasReportFile(Context c){
-		return Measurement.getEntryFile(c, this.id, this.test_name).exists();
+		return Measurement.getReportFile(c, this.id, this.test_name).exists();
 	}
 
 	public Boolean hasLogFile(Context c){
@@ -313,7 +313,7 @@ public class Measurement extends BaseModel implements Serializable {
 		List<Measurement> measurements = msmQuery.queryList();
 		for (int i = 0; i < measurements.size(); i++) {
 			Measurement measurement = measurements.get(i);
-			measurement.deleteEntryFile(c);
+			measurement.deleteReportFile(c);
 		}
 	}
 
@@ -326,7 +326,7 @@ public class Measurement extends BaseModel implements Serializable {
 	}
 
 	public void setReRun(Context c){
-		this.deleteEntryFile(c);
+		this.deleteReportFile(c);
 		this.deleteLogFile(c);
 		this.is_rerun = true;
 		this.save();

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Result.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Result.java
@@ -212,7 +212,7 @@ public class Result extends BaseModel implements Serializable {
 
 	public void delete(Context c) {
 		for (Measurement measurement : getAllMeasurements()) {
-			measurement.deleteEntryFile(c);
+			measurement.deleteReportFile(c);
 			measurement.deleteLogFile(c);
 			measurement.delete();
 		}

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -186,10 +186,10 @@ public abstract class AbstractTest implements Serializable {
 						*/
                         break;
                     case "status.measurement_submission":
-                        setUploaded(true, event.value, c);
+                        setUploaded(true, event.value);
                         break;
                     case "failure.measurement_submission":
-                        setUploaded(false, event.value , c);
+                        setUploaded(false, event.value );
                         break;
                     case "status.measurement_done":
                         setDone(event.value);
@@ -206,6 +206,7 @@ public abstract class AbstractTest implements Serializable {
                         ThirdPartyServices.logException(new MKException(event));
                         break;
                     case "task_terminated":
+                        onTaskTerminated(event.value, c);
                         /*
                          * The task will be interrupted so the current
                          * measurement data will not show up.
@@ -260,16 +261,13 @@ public abstract class AbstractTest implements Serializable {
         }
     }
 
-    private void setUploaded(Boolean uploaded, EventResult.Value value, Context context) {
+    private void setUploaded(Boolean uploaded, EventResult.Value value) {
         Measurement measurement = measurements.get(value.idx);
         if (measurement != null) {
             measurement.is_uploaded = uploaded;
             if (!uploaded) {
                 measurement.report_id = null;
                 measurement.is_upload_failed = true;
-            } else {
-                measurement.deleteEntryFile(context);
-                measurement.deleteLogFile(context);
             }
             String failure = value.failure;
             if (failure != null)
@@ -283,6 +281,16 @@ public abstract class AbstractTest implements Serializable {
         if (measurement != null) {
             measurement.is_done = true;
             measurement.save();
+        }
+    }
+
+    protected void onTaskTerminated(EventResult.Value value, Context context){
+        Measurement measurement = measurements.get(value.idx);
+        if (measurement != null) {
+            if(measurement.is_uploaded){
+                measurement.deleteEntryFile(context);
+                measurement.deleteLogFile(context);
+            }
         }
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -189,7 +189,7 @@ public abstract class AbstractTest implements Serializable {
                         setUploaded(true, event.value);
                         break;
                     case "failure.measurement_submission":
-                        setUploaded(false, event.value );
+                        setUploaded(false, event.value);
                         break;
                     case "status.measurement_done":
                         setDone(event.value);

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -169,7 +169,7 @@ public abstract class AbstractTest implements Serializable {
                                 m.rerun_network = gson.toJson(network);
                             }
                             m.save();
-                            File entryFile = Measurement.getEntryFile(c, m.id, m.test_name);
+                            File entryFile = Measurement.getReportFile(c, m.id, m.test_name);
                             entryFile.getParentFile().mkdirs();
                             FileUtils.writeStringToFile(
                                     entryFile,
@@ -288,7 +288,7 @@ public abstract class AbstractTest implements Serializable {
         Measurement measurement = measurements.get(value.idx);
         if (measurement != null) {
             if(measurement.is_uploaded){
-                measurement.deleteEntryFile(context);
+                measurement.deleteReportFile(context);
             }
         }
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -289,7 +289,6 @@ public abstract class AbstractTest implements Serializable {
         if (measurement != null) {
             if(measurement.is_uploaded){
                 measurement.deleteEntryFile(context);
-                measurement.deleteLogFile(context);
             }
         }
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -186,10 +186,10 @@ public abstract class AbstractTest implements Serializable {
 						*/
                         break;
                     case "status.measurement_submission":
-                        setUploaded(true, event.value);
+                        setUploaded(true, event.value, c);
                         break;
                     case "failure.measurement_submission":
-                        setUploaded(false, event.value);
+                        setUploaded(false, event.value , c);
                         break;
                     case "status.measurement_done":
                         setDone(event.value);
@@ -260,13 +260,16 @@ public abstract class AbstractTest implements Serializable {
         }
     }
 
-    private void setUploaded(Boolean uploaded, EventResult.Value value) {
+    private void setUploaded(Boolean uploaded, EventResult.Value value, Context context) {
         Measurement measurement = measurements.get(value.idx);
         if (measurement != null) {
             measurement.is_uploaded = uploaded;
             if (!uploaded) {
                 measurement.report_id = null;
                 measurement.is_upload_failed = true;
+            } else {
+                measurement.deleteEntryFile(context);
+                measurement.deleteLogFile(context);
             }
             String failure = value.failure;
             if (failure != null)

--- a/app/src/sharedTest/java/org/openobservatory/ooniprobe/factory/MeasurementFactory.java
+++ b/app/src/sharedTest/java/org/openobservatory/ooniprobe/factory/MeasurementFactory.java
@@ -167,7 +167,7 @@ public class MeasurementFactory {
             measurement.is_done = true;
             measurement.is_uploaded = markUploaded;
             measurement.save();
-            File entryFile = Measurement.getEntryFile(context, measurement.id, measurement.test_name);
+            File entryFile = Measurement.getReportFile(context, measurement.id, measurement.test_name);
             entryFile.getParentFile().mkdirs();
             FileUtils.writeStringToFile(
                     entryFile,

--- a/app/src/test/java/org/openobservatory/ooniprobe/client/OONIAPIClientTest.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/client/OONIAPIClientTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.openobservatory.ooniprobe.RobolectricAbstractTest;
 import org.openobservatory.ooniprobe.client.callback.CheckReportIdCallback;
 import org.openobservatory.ooniprobe.domain.callback.GetMeasurementsCallback;
-import org.openobservatory.ooniprobe.model.api.ApiMeasurement;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 
 import java.io.File;
@@ -138,7 +137,7 @@ public class OONIAPIClientTest extends RobolectricAbstractTest {
         measurement.is_uploaded = true;
         measurement.save();
         if (write_file) {
-            File entryFile = Measurement.getEntryFile(a, measurement.id, measurement.test_name);
+            File entryFile = Measurement.getReportFile(a, measurement.id, measurement.test_name);
             File parentFile = entryFile.getParentFile();
 
             if (parentFile == null) {

--- a/app/src/test/java/org/openobservatory/ooniprobe/domain/MeasurementsManagerTest.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/domain/MeasurementsManagerTest.java
@@ -3,7 +3,6 @@ package org.openobservatory.ooniprobe.domain;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
 import org.junit.Test;
 import org.openobservatory.engine.OONIContext;
 import org.openobservatory.engine.OONISession;
@@ -21,9 +20,7 @@ import org.openobservatory.ooniprobe.model.api.ApiMeasurement;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.database.Measurement_Table;
 import org.openobservatory.ooniprobe.model.database.Result;
-import org.openobservatory.ooniprobe.test.suite.PerformanceSuite;
 import org.openobservatory.ooniprobe.test.suite.WebsitesSuite;
-import org.openobservatory.ooniprobe.utils.DatabaseUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -446,7 +443,7 @@ public class MeasurementsManagerTest extends RobolectricAbstractTest {
             // Act
             boolean value = manager.reSubmit(measurement, ooniSession);
             Measurement updatedMeasurement = SQLite.select().from(Measurement.class).where(Measurement_Table.report_id.eq(newReportId)).querySingle();
-            File updatedFile = Measurement.getEntryFile(c, updatedMeasurement.id, updatedMeasurement.test_name);
+            File updatedFile = Measurement.getReportFile(c, updatedMeasurement.id, updatedMeasurement.test_name);
             String updatedFileContent = FileUtils.readFileToString(updatedFile, StandardCharsets.UTF_8);
 
             // Assert

--- a/app/src/test/java/org/openobservatory/ooniprobe/model/database/MeasurementTest.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/model/database/MeasurementTest.java
@@ -184,7 +184,7 @@ public class MeasurementTest extends RobolectricAbstractTest {
         writeReport(measurement);
         assertTrue(measurement.hasReportFile(c));
 
-        measurement.deleteEntryFile(c);
+        measurement.deleteReportFile(c);
         assertFalse(measurement.hasReportFile(c));
     }
 
@@ -464,7 +464,7 @@ public class MeasurementTest extends RobolectricAbstractTest {
 
     private void writeReport(Measurement measurement) {
         writeFile(
-                Measurement.getEntryFile(c, measurement.id, measurement.test_name)
+                Measurement.getReportFile(c, measurement.id, measurement.test_name)
         );
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 		maven { url "https://jitpack.io" }
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.2.0'
+		classpath 'com.android.tools.build:gradle:7.2.1'
 		classpath 'com.google.gms:google-services:4.3.10'
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2162

## Proposed Changes

  - [x] Delete `Measurement` log when measurement cli emits `task_terminated` and measurement has been uploaded.
  - [x] Delete `Measurement` log when measurement is re-submitted.

