### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/activity_info.xml
+++ b/app/src/main/res/layout/activity_info.xml
@@ -52,6 +52,7 @@
 
 		<Button
 			android:id="@+id/learnMore"
+			android:textColor="#057ACB"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:layout_marginTop="16dp"

--- a/app/src/main/res/layout/activity_proxy.xml
+++ b/app/src/main/res/layout/activity_proxy.xml
@@ -108,7 +108,7 @@
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:background="@color/color_blue1"
-                android:textColor="@color/color_gray6"
+                android:textColor="#5F646A"
                 android:padding="20dp"
                 android:text="@string/Settings_Proxy_Footer" />
         </LinearLayout>


### PR DESCRIPTION
The original text color of the component is '#0588CB', and the contrast between the text color ('#0588CB') and the background color ('#FFFFFF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#057ACB') are as follows:
![image](https://user-images.githubusercontent.com/101503193/185146543-4d086f95-bfc2-43d5-9799-d6b27182be4e.png)
Another example:
![image](https://user-images.githubusercontent.com/101503193/185148069-5a734a0d-1fd7-48f1-8985-8213460fae3c.png)

The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.