### PR TITLE
Add support to OONI Probe for re-testing of an anomalous URL

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -23,7 +23,6 @@ import com.google.gson.Gson;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ResubmitTask;
-import org.openobservatory.ooniprobe.domain.GetResults;
 import org.openobservatory.ooniprobe.domain.GetTestSuite;
 import org.openobservatory.ooniprobe.domain.MeasurementsManager;
 import org.openobservatory.ooniprobe.domain.callback.DomainCallback;
@@ -61,6 +60,7 @@ import org.openobservatory.ooniprobe.test.test.Whatsapp;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -276,7 +276,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.share, menu);
-        if (measurement.is_anomaly) {
+        if (Objects.equals(measurement.test_name, WebConnectivity.NAME) && measurement.is_anomaly) {
             MenuItem reRunItem = menu.findItem(R.id.reRun);
             reRunItem.setVisible(true);
         }
@@ -325,7 +325,7 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
         if (buttonClicked == DialogInterface.BUTTON_POSITIVE && extra.equals(RERUN_KEY))
             RunningActivity.runAsForegroundService(
                     this,
-                    getTestSuite.getFrom(measurement.result, Collections.singletonList(measurement.url.url)).asArray(),
+                    getTestSuite.getForWebConnectivityReRunFrom(measurement.result, Collections.singletonList(measurement.url.url)).asArray(),
                     this::finish,
                     preferenceManager);
         else if (buttonClicked == DialogInterface.BUTTON_POSITIVE)

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -23,6 +23,8 @@ import com.google.gson.Gson;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ResubmitTask;
+import org.openobservatory.ooniprobe.domain.GetResults;
+import org.openobservatory.ooniprobe.domain.GetTestSuite;
 import org.openobservatory.ooniprobe.domain.MeasurementsManager;
 import org.openobservatory.ooniprobe.domain.callback.DomainCallback;
 import org.openobservatory.ooniprobe.fragment.measurement.DashFragment;
@@ -58,6 +60,7 @@ import org.openobservatory.ooniprobe.test.test.WebConnectivity;
 import org.openobservatory.ooniprobe.test.test.Whatsapp;
 
 import java.io.Serializable;
+import java.util.Collections;
 
 import javax.inject.Inject;
 
@@ -69,6 +72,8 @@ import ru.noties.markwon.Markwon;
 
 public class MeasurementDetailActivity extends AbstractActivity implements ConfirmDialogFragment.OnConfirmedListener {
     private static final String ID = "id";
+    private static final String RERUN_KEY = "rerun";
+
     @BindView(R.id.coordinatorLayout)
     CoordinatorLayout coordinatorLayout;
     @BindView(R.id.toolbar)
@@ -90,6 +95,13 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
 
     @Inject
     PreferenceManager pm;
+
+    @Inject
+    GetTestSuite getTestSuite;
+
+    @Inject
+    PreferenceManager preferenceManager;
+
 
     public static Intent newIntent(Context context, int id) {
         return new Intent(context, MeasurementDetailActivity.class).putExtra(ID, id);
@@ -264,6 +276,10 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.share, menu);
+        if (measurement.is_anomaly) {
+            MenuItem reRunItem = menu.findItem(R.id.reRun);
+            reRunItem.setVisible(true);
+        }
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -276,6 +292,13 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
                 share.setType("text/plain");
                 Intent shareIntent = Intent. createChooser(share, null);
                 startActivity(shareIntent);
+                return true;
+            case R.id.reRun:
+                new ConfirmDialogFragment.Builder()
+                        .withExtra(RERUN_KEY)
+                        .withMessage(getString(R.string.Modal_ReRun_Title))
+                        .withPositiveButton(getString(R.string.Modal_ReRun_Websites_Run))
+                        .build().show(getSupportFragmentManager(), null);
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
@@ -299,7 +322,13 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
 
     @Override
     public void onConfirmation(Serializable extra, int buttonClicked) {
-        if (buttonClicked == DialogInterface.BUTTON_POSITIVE)
+        if (buttonClicked == DialogInterface.BUTTON_POSITIVE && extra.equals(RERUN_KEY))
+            RunningActivity.runAsForegroundService(
+                    this,
+                    getTestSuite.getFrom(measurement.result, Collections.singletonList(measurement.url.url)).asArray(),
+                    this::finish,
+                    preferenceManager);
+        else if (buttonClicked == DialogInterface.BUTTON_POSITIVE)
             runAsyncTask();
         else if (buttonClicked == DialogInterface.BUTTON_NEUTRAL)
             startActivity(TextActivity.newIntent(this, TextActivity.TYPE_UPLOAD_LOG, (String) extra));

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/GetTestSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/GetTestSuite.java
@@ -53,4 +53,28 @@ public class GetTestSuite {
 
         return testSuite;
     }
+
+    public AbstractSuite getFrom(Result result, List<String> inputs) {
+        AbstractSuite testSuite = result.getTestSuite();
+        WebConnectivity test = new WebConnectivity();
+
+        // possible NPE from measurements whose url's are null.
+        List<Url> urls = Lists.transform(
+                Lists.newArrayList(
+                        Iterables.filter(result.getMeasurements(), input -> input.url != null)
+                ),
+                measurement -> new Url(
+                        measurement.url.url,
+                        measurement.url.category_code,
+                        measurement.url.country_code
+                )
+        );
+
+        Url.saveOrUpdate(urls);
+
+        test.setInputs(inputs);
+        testSuite.setTestList(test);
+
+        return testSuite;
+    }
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/GetTestSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/GetTestSuite.java
@@ -9,9 +9,11 @@ import org.openobservatory.ooniprobe.common.Application;
 import org.openobservatory.ooniprobe.model.database.Result;
 import org.openobservatory.ooniprobe.model.database.Url;
 import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
+import org.openobservatory.ooniprobe.test.suite.WebsitesSuite;
 import org.openobservatory.ooniprobe.test.test.WebConnectivity;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -54,27 +56,31 @@ public class GetTestSuite {
         return testSuite;
     }
 
-    public AbstractSuite getFrom(Result result, List<String> inputs) {
-        AbstractSuite testSuite = result.getTestSuite();
-        WebConnectivity test = new WebConnectivity();
+    public AbstractSuite getForWebConnectivityReRunFrom(Result result, List<String> inputs) {
+        if (Objects.equals(result.getTestSuite().getName(), WebsitesSuite.NAME)){
+            AbstractSuite testSuite = result.getTestSuite();
+            WebConnectivity test = new WebConnectivity();
 
-        // possible NPE from measurements whose url's are null.
-        List<Url> urls = Lists.transform(
-                Lists.newArrayList(
-                        Iterables.filter(result.getMeasurements(), input -> input.url != null)
-                ),
-                measurement -> new Url(
-                        measurement.url.url,
-                        measurement.url.category_code,
-                        measurement.url.country_code
-                )
-        );
+            // possible NPE from measurements whose url's are null.
+            List<Url> urls = Lists.transform(
+                    Lists.newArrayList(
+                            Iterables.filter(result.getMeasurements(), input -> input.url != null)
+                    ),
+                    measurement -> new Url(
+                            measurement.url.url,
+                            measurement.url.category_code,
+                            measurement.url.country_code
+                    )
+            );
 
-        Url.saveOrUpdate(urls);
+            Url.saveOrUpdate(urls);
 
-        test.setInputs(inputs);
-        testSuite.setTestList(test);
+            test.setInputs(inputs);
+            testSuite.setTestList(test);
 
-        return testSuite;
+            return testSuite;
+        } else {
+            return null;
+        }
     }
 }

--- a/app/src/main/res/menu/share.xml
+++ b/app/src/main/res/menu/share.xml
@@ -7,4 +7,10 @@
         android:icon="@android:drawable/ic_menu_share"
         android:iconTint="@android:color/white"
         app:showAsAction="ifRoom|withText" />
+    <item
+        android:id="@+id/reRun"
+        android:icon="@drawable/rerun"
+        android:title="@string/Modal_ReRun_Websites_Run"
+        android:visible="false"
+        app:showAsAction="ifRoom|withText" />
 </menu>


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2367

## Proposed Changes

  - Add `reRun` menu option `MeasurementDetailActivity`  when the Measurement is anomalous.
  - Run test with the single URL that presets the anomaly

|.|.|
|-|-|
| ![Screenshot_20230112_132910](https://user-images.githubusercontent.com/17911892/212067627-c1e03633-ee9b-413d-bb3c-598f690b0daf.png) | ![Screenshot_20230112_132943](https://user-images.githubusercontent.com/17911892/212067666-c9bb389f-4b0d-498f-a32f-527acc07bbf3.png)|
| ![Screenshot_20230112_133022](https://user-images.githubusercontent.com/17911892/212067709-184a261b-5562-43a9-b5cf-04348a33416d.png) | ![Screenshot_20230112_132958](https://user-images.githubusercontent.com/17911892/212067696-d65c08eb-929c-45fd-b2d1-e9287447f548.png) |
| ![Screenshot_20230112_133154](https://user-images.githubusercontent.com/17911892/212067726-8872d143-da59-4e51-b8ea-e2d15e5f6237.png) | .|

