### PR TITLE
RTL support on Experimental Test overview description

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
@@ -12,6 +12,8 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
+import androidx.core.text.TextUtilsCompat;
+import androidx.core.view.ViewCompat;
 
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
@@ -20,6 +22,8 @@ import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
 import org.openobservatory.ooniprobe.test.suite.ExperimentalSuite;
 import org.openobservatory.ooniprobe.test.suite.WebsitesSuite;
 import org.openobservatory.ooniprobe.test.test.AbstractTest;
+
+import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -69,6 +73,8 @@ public class OverviewActivity extends AbstractActivity {
 					"\n\n* [Tor Snowflake](https://ooni.org/nettest/tor-snowflake/) "+ String.format(" ( %s )",getString(R.string.Settings_TestOptions_LongRunningTest))+
 					"\n\n* [Vanilla Tor](https://github.com/ooni/spec/blob/master/nettests/ts-016-vanilla-tor.md) " + String.format(" ( %s )",getString(R.string.Settings_TestOptions_LongRunningTest));
 			Markwon.setMarkdown(desc, getString(testSuite.getDesc1(), experimentalLinks));
+			if (TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL)
+				desc.setTextDirection(View.TEXT_DIRECTION_RTL);
 		}
 		else
 			Markwon.setMarkdown(desc, getString(testSuite.getDesc1()));


### PR DESCRIPTION

Fixes  https://github.com/ooni/probe/issues/2346

## Proposed Changes

  - Explicitly set text direction for `OverviewActivity` description text view if language is RTL given that the localization is dynamic.

| Before | After |
|-|-|
| ![Screenshot_20230117_120245](https://user-images.githubusercontent.com/17911892/212884482-a3609c36-4131-4e6a-8cf4-d2a15a4ce4f2.png) | ![Screenshot_20230117_120508](https://user-images.githubusercontent.com/17911892/212884520-e54ec6a3-7907-4307-94ca-1d8b34268bff.png) |
