### PR TITLE
OONI Probe Mobile remove RiseupVPN option in Settings

### DIFF
--- a/app/src/fdroid/res/xml/preferences_global.xml
+++ b/app/src/fdroid/res/xml/preferences_global.xml
@@ -272,11 +272,11 @@
 				android:key="@string/test_tor"
 				android:title="@string/Settings_Circumvention_TestTor"
 				app:iconSpaceReserved="false" />
-			<SwitchPreferenceCompat
+			<!--<SwitchPreferenceCompat
 				android:defaultValue="true"
 				android:key="@string/test_riseupvpn"
 				android:title="@string/Settings_Circumvention_TestRiseupVPN"
-				app:iconSpaceReserved="false" />
+				app:iconSpaceReserved="false" />-->
 		</PreferenceScreen>
 		<PreferenceScreen
 			android:icon="@drawable/settings_performance"

--- a/app/src/main/res/xml/preferences_global.xml
+++ b/app/src/main/res/xml/preferences_global.xml
@@ -285,11 +285,11 @@
 				android:key="@string/test_tor"
 				android:title="@string/Settings_Circumvention_TestTor"
 				app:iconSpaceReserved="false" />
-			<SwitchPreferenceCompat
+			<!--<SwitchPreferenceCompat
 				android:defaultValue="true"
 				android:key="@string/test_riseupvpn"
 				android:title="@string/Settings_Circumvention_TestRiseupVPN"
-				app:iconSpaceReserved="false" />
+				app:iconSpaceReserved="false" />-->
 		</PreferenceScreen>
 		<PreferenceScreen
 			android:icon="@drawable/settings_performance"


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2204

## Proposed Changes

  - Remove `riseupvpn` from settings.

![Screenshot_20230124_175549](https://user-images.githubusercontent.com/17911892/214357761-ef34562c-8385-48ce-af37-a96e67f3ee95.png)
