### PR TITLE
chore: use ooni/probe-cli@v3.17.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -158,7 +158,7 @@ dependencies {
 	testImplementation 'org.mockito:mockito-inline:4.6.1'
 	testImplementation 'org.robolectric:robolectric:4.5.1'
 	testImplementation 'com.github.blocoio:faker:1.2.8'
-	testImplementation 'org.ooni:oonimkall:2023.02.20-070758'
+	testImplementation 'org.ooni:oonimkall:2023.03.16-173249'
 	testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.36'
 
 	// Instrumentation Testing

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/jsonresult/EventResult.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/jsonresult/EventResult.java
@@ -8,6 +8,7 @@ public class EventResult implements Serializable {
 
 	public static class Value implements Serializable {
 		public double key;
+		public String log_level;
 		public String message;
 		public double percentage;
 		public String json_str;

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -143,7 +143,14 @@ public abstract class AbstractTest implements Serializable {
                         }
                         break;
                     case "log":
-                        logger.i(TAG,json);
+                        switch (event.value.log_level) {
+                            case "WARNING":
+                                logger.w(TAG, event.value.message);
+                                break;
+                            default:
+                                logger.i(TAG, event.value.message);
+                                break;
+                        }
                         if (logFile == null) break;
                         FileUtils.writeStringToFile(
                                 logFile,

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -32,8 +32,8 @@ android {
 dependencies {
     // For the stable and dev app flavours we're using the library
     // build published at Maven Central.
-    stableImplementation 'org.ooni:oonimkall:2023.02.20-070758'
-    devImplementation 'org.ooni:oonimkall:2023.02.20-070758'
+    stableImplementation 'org.ooni:oonimkall:2023.03.16-173249'
+    devImplementation 'org.ooni:oonimkall:2023.03.16-173249'
 
     // For the experimental flavour, you need to compile your own
     // oonimkall.aar and put it into the ../engine-experimental dir


### PR DESCRIPTION
While there, log the actual log message rather than the serialized JSON, which simplifies reading logs.

