### PR TITLE
Added version suffix for beta and experimental to match pattern `x.x.x-beta.x`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
         dev {
             dimension 'testing'
             applicationIdSuffix '.dev'
-            versionName versionNameDate()
+            versionNameSuffix "-beta.1"
             versionCode versionCodeDate()
             buildConfigField 'String', 'BASE_SOFTWARE_NAME', '"ooniprobe-android-dev"'
             resValue "string", "APP_NAME", "OONI Dev"
@@ -71,7 +71,7 @@ android {
         experimental {
             dimension 'testing'
             applicationIdSuffix '.experimental'
-            versionName versionNameDate()
+            versionNameSuffix "-experimental.1"
             versionCode versionCodeDate()
             buildConfigField 'String', 'BASE_SOFTWARE_NAME', '"ooniprobe-android-experimental"'
             resValue "string", "APP_NAME", "OONI Exp"
@@ -184,10 +184,6 @@ dependencies {
 
 static def versionCodeDate() {
     return new Date().format("yyyyMMdd").toInteger()
-}
-
-static def versionNameDate() {
-    return new Date().format("yyyy.MM.dd-HH")
 }
 
 if (!getGradle().getStartParameter().getTaskRequests()


### PR DESCRIPTION
## Proposed Changes

  - Modified `build.gradle` to to include `versionNameSuffix` for `beta` and `experimental` versions

![Screenshot_20230501_094421](https://user-images.githubusercontent.com/17911892/235430722-53c1d429-a2c6-4fa7-97a0-5d16568bbbc6.png)
