### PR TITLE
fix: Android OONI Notification Constantly wakes up mobile screen.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 	<permission
 		android:name="${applicationId}.permission.C2D_MESSAGE"


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2330

## Proposed Changes

- declare permission `POST_NOTIFICATIONS` to enable notifications to show on Android 11+ devices

