### PR TITLE
Feat: Add a setting that enables users to easily enable and disable all website categories

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManager.java
@@ -39,6 +39,7 @@ public class PreferenceManager {
 	public static final String AUTORUN_COUNT = "autorun_count";
 	public static final String AUTORUN_DATE = "autorun_last_date";
 	public static final int IGNORE_OPTIMIZATION_REQUEST = 15;
+	public static final int COUNT_WEBSITE_CATEGORIES = 31;
 	public static final int ASK_UPDATE_APP = 16;
 
 	private final SharedPreferences sp;
@@ -262,6 +263,14 @@ public class PreferenceManager {
 			if (sp.getBoolean(key, true))
 				count++;
 		return count;
+	}
+
+	public void updateAllWebsiteCategories(boolean value) {
+		SharedPreferences.Editor ed = sp.edit();
+		for (String key : r.getStringArray(R.array.CategoryCodes)){
+			ed.putBoolean(key,value);
+		}
+		ed.apply();
 	}
 
 	public boolean canCallDeleteJson(){

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/PreferenceFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/PreferenceFragment.java
@@ -1,5 +1,7 @@
 package org.openobservatory.ooniprobe.fragment;
 
+import static org.openobservatory.ooniprobe.common.PreferenceManager.COUNT_WEBSITE_CATEGORIES;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -10,9 +12,13 @@ import android.os.Bundle;
 import android.os.PowerManager;
 import android.provider.Settings;
 import android.text.TextUtils;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.widget.Toast;
 
 import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.XmlRes;
 import androidx.preference.EditTextPreference;
@@ -32,6 +38,8 @@ import org.openobservatory.ooniprobe.common.service.ServiceUtil;
 import org.openobservatory.ooniprobe.model.database.Measurement;
 
 import java.util.Arrays;
+
+import javax.inject.Inject;
 
 import localhost.toolkit.app.fragment.MessageDialogFragment;
 import localhost.toolkit.preference.ExtendedPreferenceFragment;
@@ -54,6 +62,7 @@ public class PreferenceFragment extends ExtendedPreferenceFragment<PreferenceFra
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         this.rootKey = rootKey;
+        setHasOptionsMenu(true);
     }
 
     @Override
@@ -225,5 +234,44 @@ public class PreferenceFragment extends ExtendedPreferenceFragment<PreferenceFra
                 disableScheduler();
             }
         }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
+        PreferenceScreen ourPreferenceScreen = findPreference(getString(R.string.Settings_Websites_Categories_Label));
+        if (getPreferenceScreen().equals(ourPreferenceScreen)) {
+            inflater.inflate(R.menu.website_categories, menu);
+        }
+        int enabledCategories = ((Application) getActivity().getApplication()).getPreferenceManager().countEnabledCategory();
+
+        if (enabledCategories>=COUNT_WEBSITE_CATEGORIES){
+            MenuItem item = menu.findItem(R.id.selectAll);
+            if (item != null) {
+                item.setVisible(false);
+            }
+        } else if (enabledCategories<=0){
+            MenuItem item = menu.findItem(R.id.selectNone);
+            if (item != null) {
+                item.setVisible(false);
+            }
+        }
+
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        PreferenceManager preferenceManager = ((Application) getActivity().getApplication()).getPreferenceManager();
+        int itemId = item.getItemId();
+        if (itemId == R.id.selectAll) {
+            preferenceManager.updateAllWebsiteCategories(true);
+            getActivity().recreate();
+            return true;
+        } else if (itemId == R.id.selectNone) {
+            preferenceManager.updateAllWebsiteCategories(false);
+            getActivity().recreate();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/res/menu/website_categories.xml
+++ b/app/src/main/res/menu/website_categories.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+	<item
+		android:id="@+id/selectAll"
+		android:title="@string/Settings_Websites_Categories_Selection_All" />
+	<item
+		android:id="@+id/selectNone"
+		android:title="@string/Settings_Websites_Categories_Selection_None" />
+</menu>


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2465

## Proposed Changes

  - Add menu option to select/unselect all website categories

|.|.|
|-|-|
| ![Screenshot_20230615_083450](https://github.com/ooni/probe-android/assets/17911892/6eb56a91-5bf4-4c0f-864a-f8ed4caeaee7) | ![Screenshot_20230615_083511](https://github.com/ooni/probe-android/assets/17911892/89fd2d45-40b1-4d90-9480-861bc52b047f) |
