### PR TITLE
chore: update to ooni/probe-cli@v3.17.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -158,7 +158,7 @@ dependencies {
 	testImplementation 'org.mockito:mockito-inline:4.6.1'
 	testImplementation 'org.robolectric:robolectric:4.5.1'
 	testImplementation 'com.github.blocoio:faker:1.2.8'
-	testImplementation 'org.ooni:oonimkall:2023.05.11-061958'
+	testImplementation 'org.ooni:oonimkall:2023.06.06-083629'
 	testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.36'
 
 	// Instrumentation Testing

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -32,8 +32,8 @@ android {
 dependencies {
     // For the stable and dev app flavours we're using the library
     // build published at Maven Central.
-    stableImplementation 'org.ooni:oonimkall:2023.05.11-061958'
-    devImplementation 'org.ooni:oonimkall:2023.05.11-061958'
+    stableImplementation 'org.ooni:oonimkall:2023.06.06-083629'
+    devImplementation 'org.ooni:oonimkall:2023.06.06-083629'
 
     // For the experimental flavour, you need to compile your own
     // oonimkall.aar and put it into the ../engine-experimental dir


### PR DESCRIPTION
This diff updates to probe-cli@v3.17.4, which includes the following fixes:

* 🚧 feat: use 2023-06 geoip database https://github.com/ooni/probe-cli/commit/56438f2c1cdffb2f8c7d9f583615e4764e0f9a7b
* 🐛 fix(oohelperd): use cookiejar for HTTP measurements https://github.com/ooni/probe-cli/commit/a3af5542986e314a4e766d36078bedbae5c977ef
* 🐛 fix: use openssl-1.1.1u https://github.com/ooni/probe-cli/commit/325a8412999b001f4913ab5c522ed6402c9d78fe

Related issue: https://github.com/ooni/probe/issues/2485.