### PR TITLE
Fix: cannot move app to SD-Card

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	android:installLocation="auto">
 
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2019

## Proposed Changes

  - Modified android manifest to allow app installation in sd-card 

![Screenshot_20230628_113830](https://github.com/ooni/probe-android/assets/17911892/bf53f86a-658e-4b90-be4d-79ee652402a5)
