### PR TITLE
fix: log view crashes when using debug logs

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/adapters/LogRecyclerViewAdapter.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/adapters/LogRecyclerViewAdapter.java
@@ -83,6 +83,9 @@ public class LogRecyclerViewAdapter extends RecyclerView.Adapter<LogRecyclerView
                 case API:
                     viewHolder.binding.textView.setTextColor(context.getResources().getColor(R.color.color_blue9));
                     break;
+                default:
+                    viewHolder.binding.textView.setTextColor(context.getResources().getColor(R.color.color_black));
+                    break;
             }
         }catch (Exception e){
             System.out.println(items.get(position).trim());

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/PreferenceGlobalFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/PreferenceGlobalFragment.java
@@ -8,22 +8,22 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
 import org.openobservatory.ooniprobe.R;
-
-import butterknife.BindView;
-import butterknife.ButterKnife;
+import org.openobservatory.ooniprobe.databinding.FragmentContentBinding;
 
 public class PreferenceGlobalFragment extends Fragment {
-	@BindView(R.id.toolbar) Toolbar toolbar;
 
 	@Nullable @Override public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-		View v = inflater.inflate(R.layout.fragment_content, container, false);
-		ButterKnife.bind(this, v);
-		((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
+		FragmentContentBinding binding = FragmentContentBinding.inflate(inflater);
+		((AppCompatActivity) getActivity()).setSupportActionBar(binding.toolbar);
+		return binding.getRoot();
+	}
+
+	@Override
+	public void onStart() {
+		super.onStart();
 		getParentFragmentManager().beginTransaction().replace(R.id.subContent, PreferenceFragment.newInstance(R.xml.preferences_global, R.id.subContent, null)).commit();
-		return v;
 	}
 }

--- a/applogger/src/main/java/org/openobservatory/applogger/LogType.kt
+++ b/applogger/src/main/java/org/openobservatory/applogger/LogType.kt
@@ -1,9 +1,9 @@
 package org.openobservatory.applogger
 
 enum class LogType {
-    ALL, ERROR, WARNING, INFO, API;
+    ALL, DEBUG, ERROR, WARNING, INFO, API;
 
     companion object {
-        fun getAllTypes() = listOf(ALL.name, ERROR.name, WARNING.name, INFO.name, API.name)
+        fun getAllTypes() = listOf(ALL.name, DEBUG.name, ERROR.name, WARNING.name, INFO.name, API.name)
     }
 }

--- a/applogger/src/main/java/org/openobservatory/applogger/LoggerManager.kt
+++ b/applogger/src/main/java/org/openobservatory/applogger/LoggerManager.kt
@@ -20,7 +20,11 @@ abstract class LoggerManager(private val context: Context) : ILogger, Subject {
     companion object {
         @JvmStatic
         fun getTag(line: String): String {
-            return line.substring(24).trim().split(":").first().trim()
+            return try {
+                line.substring(24).trim().split(":").first().trim()
+            } catch (e: Exception) {
+                "DEBUG"
+            }
         }
     }
 


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2508

## Proposed Changes

  - Migrate from `Butterknife` to `ViewBinding` in `PreferenceGlobalFragment`, moving fragment replacement to `onStart` to prevent race condition
  -  Adds safe defaults for instances where logs are empty cased by debug logs.
 
