### PR TITLE
fix: missing prompt to enable notifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     implementation project(path: ':engine')
 
 // AndroidX
-	implementation 'androidx.appcompat:appcompat:1.4.2'
+	implementation 'androidx.appcompat:appcompat:1.6.1'
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 	implementation 'androidx.lifecycle:lifecycle-process:2.5.1'
 	implementation 'androidx.preference:preference:1.2.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
 	<permission
 		android:name="${applicationId}.permission.C2D_MESSAGE"
@@ -174,6 +175,7 @@
 		<service
 			android:name=".common.service.RunTestService"
 			android:icon="@drawable/notification_icon"
+			android:foregroundServiceType="specialUse"
 			android:label="@string/Dashboard_Card_Run"/>
 		<service
 			android:name=".common.service.RunTestJobService"

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MainActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MainActivity.java
@@ -1,23 +1,34 @@
 package org.openobservatory.ooniprobe.activity;
 
+import static org.openobservatory.ooniprobe.common.service.RunTestService.CHANNEL_ID;
+
+import android.Manifest;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.provider.Settings;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.content.ContextCompat;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.snackbar.Snackbar;
 
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.Application;
+import org.openobservatory.ooniprobe.common.NotificationUtility;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.common.service.ServiceUtil;
+import org.openobservatory.ooniprobe.databinding.ActivityMainBinding;
 import org.openobservatory.ooniprobe.domain.UpdatesNotificationManager;
 import org.openobservatory.ooniprobe.fragment.DashboardFragment;
 import org.openobservatory.ooniprobe.fragment.PreferenceGlobalFragment;
@@ -37,14 +48,15 @@ public class MainActivity extends AbstractActivity implements ConfirmDialogFragm
     public static final String AUTOTEST_DIALOG = "automatic_testing";
     public static final String BATTERY_DIALOG = "battery_optimization";
 
-    @BindView(R.id.bottomNavigation)
-    BottomNavigationView bottomNavigation;
+    private ActivityMainBinding binding;
 
     @Inject
     UpdatesNotificationManager notificationManager;
 
     @Inject
     PreferenceManager preferenceManager;
+
+    private ActivityResultLauncher<String> requestPermissionLauncher;
 
     public static Intent newIntent(Context context, int resItem) {
         return new Intent(context, MainActivity.class).putExtra(RES_ITEM, resItem).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
@@ -59,9 +71,10 @@ public class MainActivity extends AbstractActivity implements ConfirmDialogFragm
             finish();
         }
         else {
-            setContentView(R.layout.activity_main);
             ButterKnife.bind(this);
-            bottomNavigation.setOnNavigationItemSelectedListener(item -> {
+            binding = ActivityMainBinding.inflate(getLayoutInflater());
+            setContentView(binding.getRoot());
+            binding.bottomNavigation.setOnItemSelectedListener(item -> {
                 switch (item.getItemId()) {
                     case R.id.dashboard:
                         getSupportFragmentManager().beginTransaction().replace(R.id.content, new DashboardFragment()).commit();
@@ -76,7 +89,7 @@ public class MainActivity extends AbstractActivity implements ConfirmDialogFragm
                         return false;
                 }
             });
-            bottomNavigation.setSelectedItemId(getIntent().getIntExtra(RES_ITEM, R.id.dashboard));
+            binding.bottomNavigation.setSelectedItemId(getIntent().getIntExtra(RES_ITEM, R.id.dashboard));
             if (notificationManager.shouldShowAutoTest()) {
                 new ConfirmDialogFragment.Builder()
                         .withTitle(getString(R.string.Modal_Autorun_Modal_Title))
@@ -109,7 +122,45 @@ public class MainActivity extends AbstractActivity implements ConfirmDialogFragm
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
             }
         }
+        requestNotificationPermission();
+    }
 
+    private void requestNotificationPermission() {
+
+        requestPermissionLauncher = registerForActivityResult(
+                new ActivityResultContracts.RequestPermission(),
+                (result) -> {
+                    if (!result) {
+                        Snackbar.make(
+                                binding.getRoot(),
+                                "Please grant Notification permission from App Settings",
+                                Snackbar.LENGTH_LONG
+                                ).setAction(R.string.Settings_Title, view -> {
+                                    Intent intent = new Intent();
+                                    intent.setAction("android.settings.APP_NOTIFICATION_SETTINGS");
+                                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+                                    //for Android 5-7
+                                    intent.putExtra("app_package", getPackageName());
+                                    intent.putExtra("app_uid", getApplicationInfo().uid);
+
+                                    // for Android 8 and above
+                                    intent.putExtra("android.provider.extra.APP_PACKAGE", getPackageName());
+
+                                    startActivity(intent);
+                                }).show();
+                    }
+                }
+        );
+        NotificationUtility.setChannel(getApplicationContext(), CHANNEL_ID, getString(R.string.Settings_AutomatedTesting_Label), false, false, false);
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+            }
+        }
     }
 
     @Override
@@ -117,7 +168,7 @@ public class MainActivity extends AbstractActivity implements ConfirmDialogFragm
         super.onNewIntent(intent);
         if (intent.getExtras() != null){
             if (intent.getExtras().containsKey(RES_ITEM))
-                bottomNavigation.setSelectedItemId(intent.getIntExtra(RES_ITEM, R.id.dashboard));
+                binding.bottomNavigation.setSelectedItemId(intent.getIntExtra(RES_ITEM, R.id.dashboard));
             else if (intent.getExtras().containsKey(NOTIFICATION_DIALOG)){
                 new ConfirmDialogFragment.Builder()
                         .withTitle(intent.getExtras().getString("title"))

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/service/RunTestService.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/service/RunTestService.java
@@ -1,5 +1,6 @@
 package org.openobservatory.ooniprobe.common.service;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.app.KeyguardManager;
@@ -9,16 +10,16 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.os.Binder;
 import android.os.IBinder;
 import android.util.Log;
 
+import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
+import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.activity.MainActivity;
@@ -47,7 +48,7 @@ public class RunTestService extends Service {
         super.onCreate();
         IntentFilter filter = new IntentFilter(ACTION_INTERRUPT);
         receiver = new ActionReceiver();
-        this.registerReceiver(receiver, filter);
+        ContextCompat.registerReceiver(this, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
 
         LocalBroadcastManager.getInstance(this).registerReceiver(
                 new ProgressBroadcastReceiver(),
@@ -110,6 +111,12 @@ public class RunTestService extends Service {
                     .setContentIntent(pendingIntent)
                     .setAutoCancel(true)
                     .setProgress(100, 100, false);
+            if (ActivityCompat.checkSelfPermission(
+                    RunTestService.this,
+                    Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+            ) {
+                return;
+            }
             notificationManager.notify(1, builder.build());
         } else if (notificationManager != null)
             notificationManager.cancel(NOTIFICATION_ID);
@@ -195,6 +202,12 @@ public class RunTestService extends Service {
         public void onReceive(Context context, Intent intent) {
             String key = intent.getStringExtra("key");
             String value = intent.getStringExtra("value");
+            if (ActivityCompat.checkSelfPermission(
+                    RunTestService.this,
+                    Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+            ) {
+                return;
+            }
             switch (key) {
                 case TestAsyncTask.RUN:
                     Log.d(TAG, "TestAsyncTask.RUN");


### PR DESCRIPTION

Fixes  https://github.com/ooni/probe/issues/2507

## Proposed Changes

  - Update app to request for `android.permission.POST_NOTIFICATIONS` in `MainActivity`
  - Prepare `RunTestService` to run on android API `34`
