### PR TITLE
Fix: Update rules for displaying an error message when test starts

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/item/FailedItem.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/item/FailedItem.java
@@ -13,7 +13,9 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.model.database.Result;
 
+import java.util.Date;
 import java.util.Locale;
+import static java.util.concurrent.TimeUnit.*;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -42,8 +44,19 @@ public class FailedItem extends HeterogeneousRecyclerItem<Result, FailedItem.Vie
 		viewHolder.icon.setImageResource(extra.getTestSuite().getIcon());
 		viewHolder.testName.setText(extra.getTestSuite().getTitle());
 		String failure_msg = viewHolder.itemView.getContext().getString(R.string.TestResults_Overview_Error);
-		if (extra.failure_msg != null)
+		if (extra.failure_msg != null) {
 			failure_msg += " - " + extra.failure_msg;
+		} else {
+			// NOTE: If the test is running for more than 5 minutes, we assume it's stuck or failed,
+			// and we show the default error message.
+			long MAX_DURATION = MILLISECONDS.convert(5, MINUTES);
+			long duration = new Date().getTime() - extra.start_time.getTime();
+			if (duration < MAX_DURATION) {
+				failure_msg = viewHolder.itemView.getContext()
+						.getString(R.string.Dashboard_Running_Running)
+						.replace(":","");
+			}
+		}
 		viewHolder.subtitle.setText(failure_msg);
 		viewHolder.startTime.setText(DateFormat.format(DateFormat.getBestDateTimePattern(Locale.getDefault(), "yMdHm"), extra.start_time));
 	}


### PR DESCRIPTION
## Proposed Changes

  - Only display an error message if the `start_time` of the test is more than 5 minutes ago.

![Screenshot_20230904_090258](https://github.com/ooni/probe-android/assets/17911892/57af92a1-464c-4a89-8fc4-c899ee11a62c)
