### PR TITLE
Chore: Update from `ru.noties:markwon:2.0.1` to `io.noties.markwon:core:4.6.2`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,7 @@ dependencies {
 
     implementation libs.xanscale.localhost.toolkit
     implementation libs.lottie
-    implementation libs.markwon
+    implementation libs.markwon.core
     implementation libs.commons.io
     //arcview to fragment_dashboard
     implementation libs.shapeofview

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -27,7 +27,7 @@ import org.openobservatory.ooniprobe.model.database.Measurement;
 import org.openobservatory.ooniprobe.model.database.Network;
 import org.openobservatory.ooniprobe.test.suite.PerformanceSuite;
 import org.openobservatory.ooniprobe.test.test.*;
-import ru.noties.markwon.Markwon;
+import io.noties.markwon.Markwon;
 
 import javax.inject.Inject;
 import java.io.Serializable;
@@ -212,7 +212,9 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
             binding.log.setVisibility(View.GONE);
         if (!measurementsManager.hasReportId(measurement))
             binding.explorer.setVisibility(View.GONE);
-        Markwon.setMarkdown(binding.methodology, getString(R.string.TestResults_Details_Methodology_Paragraph, getString(measurement.getTest().getUrlResId())));
+        Markwon.builder(this)
+                .build()
+                .setMarkdown(binding.methodology, getString(R.string.TestResults_Details_Methodology_Paragraph, getString(measurement.getTest().getUrlResId())));
         load();
         binding.log.setOnClickListener(v -> logClick());
         binding.data.setOnClickListener(v -> dataClick());

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
-import ru.noties.markwon.Markwon;
+import io.noties.markwon.Markwon;
 
 public class OverviewActivity extends AbstractActivity {
 	private static final String TEST = "test";
@@ -54,6 +54,7 @@ public class OverviewActivity extends AbstractActivity {
 			binding.run.setAlpha(0.5F);
 			binding.run.setEnabled(false);
 		}
+		Markwon markwon = Markwon.builder(this).build();
 		if (testSuite.getName().equals(ExperimentalSuite.NAME)) {
 			String experimentalLinks =
 					"\n\n* [STUN Reachability](https://github.com/ooni/spec/blob/master/nettests/ts-025-stun-reachability.md)" +
@@ -61,12 +62,12 @@ public class OverviewActivity extends AbstractActivity {
 					"\n\n* [ECH Check](https://github.com/ooni/spec/blob/master/nettests/ts-039-echcheck.md)" +
 					"\n\n* [Tor Snowflake](https://ooni.org/nettest/tor-snowflake/) "+ String.format(" ( %s )",getString(R.string.Settings_TestOptions_LongRunningTest))+
 					"\n\n* [Vanilla Tor](https://github.com/ooni/spec/blob/master/nettests/ts-016-vanilla-tor.md) " + String.format(" ( %s )",getString(R.string.Settings_TestOptions_LongRunningTest));
-			Markwon.setMarkdown(binding.desc, getString(testSuite.getDesc1(), experimentalLinks));
+			markwon.setMarkdown(binding.desc, getString(testSuite.getDesc1(), experimentalLinks));
 			if (TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()) == ViewCompat.LAYOUT_DIRECTION_RTL)
 				binding.desc.setTextDirection(View.TEXT_DIRECTION_RTL);
 		}
 		else
-			Markwon.setMarkdown(binding.desc, getString(testSuite.getDesc1()));
+			markwon.setMarkdown(binding.desc, getString(testSuite.getDesc1()));
 		Result lastResult = Result.getLastResult(testSuite.getName());
 		if (lastResult == null)
 			binding.lastTime.setText(R.string.Dashboard_Overview_LastRun_Never);

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/ProxyActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/ProxyActivity.java
@@ -14,7 +14,7 @@ import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ProxyProtocol;
 import org.openobservatory.ooniprobe.common.ProxySettings;
 import org.openobservatory.ooniprobe.databinding.ActivityProxyBinding;
-import ru.noties.markwon.Markwon;
+import io.noties.markwon.Markwon;
 
 import javax.inject.Inject;
 import java.net.URISyntaxException;
@@ -119,7 +119,9 @@ public class ProxyActivity extends AbstractActivity {
         setContentView(binding.getRoot());
 
         // We fill the footer that helps users to understand this settings screen.
-        Markwon.setMarkdown(binding.proxyFooter, getString(R.string.Settings_Proxy_Footer));
+        Markwon.builder(this)
+                .build()
+                .setMarkdown(binding.proxyFooter, getString(R.string.Settings_Proxy_Footer));
 
         // We read settings and configure the initial view.
         loadSettingsAndConfigureInitialView();

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/PsiphonFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/PsiphonFragment.java
@@ -10,7 +10,8 @@ import androidx.fragment.app.Fragment;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.databinding.FragmentMeasurementPsiphonBinding;
 import org.openobservatory.ooniprobe.model.database.Measurement;
-import ru.noties.markwon.Markwon;
+
+import io.noties.markwon.Markwon;
 
 public class PsiphonFragment extends Fragment {
 	private static final String MEASUREMENT = "measurement";
@@ -28,7 +29,9 @@ public class PsiphonFragment extends Fragment {
 		Measurement measurement = (Measurement) getArguments().getSerializable(MEASUREMENT);
 		assert measurement != null;
 		FragmentMeasurementPsiphonBinding binding = FragmentMeasurementPsiphonBinding.inflate(inflater,container,false);
-		Markwon.setMarkdown(binding.desc,
+		Markwon.builder(getContext())
+				.build()
+				.setMarkdown(binding.desc,
 				measurement.is_anomaly ?
 						getString(R.string.TestResults_Details_Circumvention_Psiphon_Blocked_Content_Paragraph) :
 						getString(R.string.TestResults_Details_Circumvention_Psiphon_Reachable_Content_Paragraph)

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/RiseupVPNFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/RiseupVPNFragment.java
@@ -10,7 +10,8 @@ import androidx.fragment.app.Fragment;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.databinding.FragmentMeasurementRiseupvpnBinding;
 import org.openobservatory.ooniprobe.model.database.Measurement;
-import ru.noties.markwon.Markwon;
+
+import io.noties.markwon.Markwon;
 
 public class RiseupVPNFragment extends Fragment {
 	private static final String MEASUREMENT = "measurement";
@@ -28,7 +29,9 @@ public class RiseupVPNFragment extends Fragment {
 		Measurement measurement = (Measurement) getArguments().getSerializable(MEASUREMENT);
 		assert measurement != null;
 		FragmentMeasurementRiseupvpnBinding binding = FragmentMeasurementRiseupvpnBinding.inflate(inflater,container,false);
-		Markwon.setMarkdown(binding.desc,
+		Markwon.builder(getContext())
+				.build()
+				.setMarkdown(binding.desc,
 				measurement.is_anomaly ?
 						getString(R.string.TestResults_Details_Circumvention_RiseupVPN_Blocked_Content_Paragraph) :
 						getString(R.string.TestResults_Details_Circumvention_RiseupVPN_Reachable_Content_Paragraph)

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/TorFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/TorFragment.java
@@ -10,7 +10,8 @@ import androidx.fragment.app.Fragment;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.databinding.FragmentMeasurementTorBinding;
 import org.openobservatory.ooniprobe.model.database.Measurement;
-import ru.noties.markwon.Markwon;
+
+import io.noties.markwon.Markwon;
 
 public class TorFragment extends Fragment {
 	private static final String MEASUREMENT = "measurement";
@@ -30,7 +31,9 @@ public class TorFragment extends Fragment {
 		Measurement measurement = (Measurement) getArguments().getSerializable(MEASUREMENT);
 		assert measurement != null;
 		FragmentMeasurementTorBinding binding = FragmentMeasurementTorBinding.inflate(inflater,container,false);
-		Markwon.setMarkdown(binding.desc,
+		Markwon.builder(getContext())
+				.build()
+				.setMarkdown(binding.desc,
 				measurement.is_anomaly ?
 						getString(R.string.TestResults_Details_Circumvention_Tor_Blocked_Content_Paragraph) :
 						getString(R.string.TestResults_Details_Circumvention_Tor_Reachable_Content_Paragraph)

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/WebConnectivityFragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/measurement/WebConnectivityFragment.java
@@ -10,7 +10,8 @@ import androidx.fragment.app.Fragment;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.databinding.FragmentMeasurementWebconnectivityBinding;
 import org.openobservatory.ooniprobe.model.database.Measurement;
-import ru.noties.markwon.Markwon;
+
+import io.noties.markwon.Markwon;
 
 public class WebConnectivityFragment extends Fragment {
 	private static final String MEASUREMENT = "measurement";
@@ -30,10 +31,11 @@ public class WebConnectivityFragment extends Fragment {
 		Measurement measurement = (Measurement) getArguments().getSerializable(MEASUREMENT);
 		assert measurement != null;
 		FragmentMeasurementWebconnectivityBinding binding = FragmentMeasurementWebconnectivityBinding.inflate(inflater,container,false);
+		Markwon markwon = Markwon.builder(getContext()).build();
 		if (measurement.is_anomaly)
-			Markwon.setMarkdown(binding.desc, getString(R.string.TestResults_Details_Websites_LikelyBlocked_Content_Paragraph, measurement.url.url, getString(measurement.getTestKeys().getWebsiteBlocking())));
+			markwon.setMarkdown(binding.desc, getString(R.string.TestResults_Details_Websites_LikelyBlocked_Content_Paragraph, measurement.url.url, getString(measurement.getTestKeys().getWebsiteBlocking())));
 		else
-			Markwon.setMarkdown(binding.desc, getString(R.string.TestResults_Details_Websites_Reachable_Content_Paragraph, measurement.url.url));
+			markwon.setMarkdown(binding.desc, getString(R.string.TestResults_Details_Websites_Reachable_Content_Paragraph, measurement.url.url));
 		return binding.getRoot();
 	}
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/onboarding/Onboarding3Fragment.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/onboarding/Onboarding3Fragment.java
@@ -14,7 +14,7 @@ import org.openobservatory.ooniprobe.common.PreferenceManager;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.common.service.ServiceUtil;
 import org.openobservatory.ooniprobe.databinding.FragmentOnboarding3Binding;
-import ru.noties.markwon.Markwon;
+import io.noties.markwon.Markwon;
 
 import javax.inject.Inject;
 
@@ -31,7 +31,9 @@ public class Onboarding3Fragment extends Fragment {
 		binding.bullet1.setText(getString(R.string.bullet, getString(R.string.Onboarding_DefaultSettings_Bullet_1)));
 		binding.bullet2.setText(getString(R.string.bullet, getString(R.string.Onboarding_DefaultSettings_Bullet_2)));
 		binding.bullet3.setText(getString(R.string.bullet, getString(R.string.Onboarding_DefaultSettings_Bullet_3)));
-		Markwon.setMarkdown(binding.paragraph, getString(R.string.Onboarding_DefaultSettings_Paragraph));
+		Markwon.builder(getContext())
+				.build()
+				.setMarkdown(binding.paragraph, getString(R.string.Onboarding_DefaultSettings_Paragraph));
 
 		binding.master.setOnClickListener(v -> masterClick());
 		binding.slave.setOnClickListener(v -> slaveClick());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
 
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
-markwon = { module = "io.noties.markwon:core", version.ref = "markwon" }
+markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon" }
 retrofit-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofitCore" }
 retrofit-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "retrofitLoggingInterceptor" }
 retrofit-lib = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofitCore" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ googlePlaycore = "1.10.3"
 # OONI
 compileSdk = "34"
 lottie = "3.0.7"
-markwon = "2.0.1"
+markwon = "4.6.2"
 shapeofview = "1.3.2"
 targetSdk = "33"
 minSdk = "21"
@@ -69,7 +69,7 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
 
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
-markwon = { module = "ru.noties:markwon", version.ref = "markwon" }
+markwon = { module = "io.noties.markwon:core", version.ref = "markwon" }
 retrofit-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofitCore" }
 retrofit-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "retrofitLoggingInterceptor" }
 retrofit-lib = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofitCore" }


### PR DESCRIPTION
## Proposed Changes

  - Update from `ru.noties:markwon:2.0.1` to `io.noties.markwon:core:4.6.2`
  - Update required API usage.

Note: This update will allow us to use the `markwon` [plugin system](https://noties.io/Markwon/docs/v4/core/plugins.html) to implement additional functionality like the [Read more](https://github.com/noties/Markwon/blob/v4.6.2/app-sample/src/main/java/io/noties/markwon/app/samples/ReadMorePluginSample.java#L48C7-L208) which is added as part of the new designs.