### PR TITLE
Chore: Add support for sending build to firebase app distribution

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: build release
-        run: ./gradlew clean assembleDevFullRelease
+        run: ./gradlew clean assembleDevFullDebug
       - name: upload artifact to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1.7.0
         with:
           appId: ${{secrets.FIREBASE_APP_ID}}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: testers
-          file: app/build/outputs/apk/devFull/release/app-dev-full-release-unsigned.apk
+          file: app/build/outputs/apk/devFull/debug/app-dev-full-debug.apk

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -1,0 +1,25 @@
+name: Build & upload to Firebase App Distribution
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: build release
+        run: ./gradlew clean assembleDevFullRelease
+      - name: upload artifact to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.7.0
+        with:
+          appId: ${{secrets.FIREBASE_APP_ID}}
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+          groups: testers
+          file: app/build/outputs/apk/devFull/release/app-dev-full-release-unsigned.apk

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2643

## Proposed Changes

  - Adds Credentials to the repo
  - Add a new workflow file for Firebase App Distribution which publishes debug `apk`.
 
