### PR TITLE
Feat: Add task to build experimental engine in android

### DIFF
--- a/.github/workflows/build_experimental_engine.yml
+++ b/.github/workflows/build_experimental_engine.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get GOVERSION content
         id: goversion
-        run: echo "version=$(cat GOVERSION)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(curl https://raw.githubusercontent.com/ooni/probe-cli/master/GOVERSION && cat GOVERSION)" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - uses: magnetikonline/action-golang-cache@v4

--- a/.github/workflows/build_experimental_engine.yml
+++ b/.github/workflows/build_experimental_engine.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: magnetikonline/action-golang-cache@v4
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
-          cache-key-suffix: "-coverage-${{ steps.goversion.outputs.version }}"
+          cache-key-suffix: "-build-experimental-engine-${{ steps.goversion.outputs.version }}"
 
       - name: Build Experimental Archive from `ooni/probe-cli`
         run: ./gradlew buildExperimentalArchive

--- a/.github/workflows/build_experimental_engine.yml
+++ b/.github/workflows/build_experimental_engine.yml
@@ -1,9 +1,15 @@
-name: build_experimental_engine
+name: Build Experimental Engine
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "0 2 * * */2"
 
 jobs:
-  build_android:
+  build_experimental_engine:
     runs-on: ubuntu-22.04
 
     steps:
@@ -30,3 +36,12 @@ jobs:
 
       - name: Build Experimental Archive from `ooni/probe-cli`
         run: ./gradlew buildExperimentalArchive
+
+      - name: Build Experimental App
+        run: ./gradlew assembleExperimentalFullDebug
+
+      - name: Archive Experimental APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-experimental-full-debug
+          path: app/build/outputs/apk/experimentalFull/debug/app-experimental-full-debug.apk

--- a/.github/workflows/build_experimental_engine.yml
+++ b/.github/workflows/build_experimental_engine.yml
@@ -1,0 +1,32 @@
+name: build_experimental_engine
+
+on: [push]
+
+jobs:
+  build_android:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Get GOVERSION content
+        id: goversion
+        run: echo "version=$(cat GOVERSION)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - uses: magnetikonline/action-golang-cache@v4
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+          cache-key-suffix: "-coverage-${{ steps.goversion.outputs.version }}"
+
+      - name: Build Experimental Archive from `ooni/probe-cli`
+        run: ./gradlew buildExperimentalArchive

--- a/.github/workflows/build_experimental_engine.yml
+++ b/.github/workflows/build_experimental_engine.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_experimental_engine:
-    runs-on: macos-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_experimental_engine.yml
+++ b/.github/workflows/build_experimental_engine.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_experimental_engine:
-    runs-on: ubuntu-22.04
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -26,5 +26,5 @@ task clean(type: Delete, dependsOn: ':engine-experimental:clean') {
 }
 
 task buildExperimentalArchive(dependsOn: ':engine-experimental:buildExperimentalArchive') {
-	println "main"
+	println "invoking buildExperimentalArchive"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,10 @@ allprojects {
 	}
 }
 
-task clean(type: Delete) {
+task clean(type: Delete, dependsOn: ':engine-experimental:clean') {
 	delete rootProject.buildDir
+}
+
+task buildExperimentalArchive(dependsOn: ':engine-experimental:buildExperimentalArchive') {
+	println "main"
 }

--- a/engine-experimental/.gitignore
+++ b/engine-experimental/.gitignore
@@ -1,1 +1,2 @@
 /oonimkall.aar
+/oonimkall-sources.jar

--- a/engine-experimental/build.gradle
+++ b/engine-experimental/build.gradle
@@ -1,2 +1,12 @@
 configurations.maybeCreate("default")
 artifacts.add("default", file('oonimkall.aar'))
+
+task clean(type: Delete) {
+    delete 'oonimkall.aar'
+    delete 'oonimkall-sources.jar'
+}
+
+task buildExperimentalArchive(type: Exec) {
+    commandLine 'sh', 'mkdir' , '-p' , rootProject.buildDir
+    commandLine 'sh', "../scripts/build_experimental_archive.sh" , project.property('ooni.experimental.target') , rootProject.buildDir
+}

--- a/engine-experimental/gradle.example.properties
+++ b/engine-experimental/gradle.example.properties
@@ -1,0 +1,1 @@
+ooni.experimental.target=master

--- a/engine-experimental/gradle.properties
+++ b/engine-experimental/gradle.properties
@@ -1,0 +1,1 @@
+ooni.experimental.target=master

--- a/scripts/build_experimental_archive.sh
+++ b/scripts/build_experimental_archive.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-#set -euxo pipefail
+set -euxo pipefail
 
 # Define build and output directories
 gitTarget=${1:-"master"}

--- a/scripts/build_experimental_archive.sh
+++ b/scripts/build_experimental_archive.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eux
+set -euxo pipefail
 
 # Define build and output directories
 gitTarget=${1:-"master"}

--- a/scripts/build_experimental_archive.sh
+++ b/scripts/build_experimental_archive.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Define build and output directories
+gitTarget=${1:-"master"}
+buildDir=${2:-"./build"}
+
+# Create build directory and navigate into it
+mkdir -p "${buildDir}" && cd "${buildDir}"
+
+# Clone the repository
+git clone -v https://github.com/ooni/probe-cli.git
+
+# Navigate into the repository
+cd probe-cli
+
+git checkout master
+
+git pull origin
+# Checkout the target branch
+git checkout -c "${gitTarget}"
+
+# Build the probe-cli
+make android
+
+cp -v ./MOBILE/android/oonimkall.aar ../../engine-experimental/
+cp -v ./MOBILE/android/oonimkall-sources.jar ../../engine-experimental/
+
+
+echo "* Fetching geoip databases"

--- a/scripts/build_experimental_archive.sh
+++ b/scripts/build_experimental_archive.sh
@@ -26,4 +26,4 @@ cp -v ./MOBILE/android/oonimkall.aar ../../engine-experimental/
 cp -v ./MOBILE/android/oonimkall-sources.jar ../../engine-experimental/
 
 
-echo "* Fetching geoip databases"
+echo "Done building engine archive."

--- a/scripts/build_experimental_archive.sh
+++ b/scripts/build_experimental_archive.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -euxo pipefail
+#set -euxo pipefail
 
 # Define build and output directories
 gitTarget=${1:-"master"}

--- a/scripts/build_experimental_archive.sh
+++ b/scripts/build_experimental_archive.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -euxo pipefail
+set -eux
 
 # Define build and output directories
 gitTarget=${1:-"master"}


### PR DESCRIPTION
Fixes # <issue>

## Proposed Changes

  - Add a Gradle task to build `experimental-engine` from Android App.
  - Ensure the clean task deletes the existing engine archive.

```shell
./gradlew clean buildExperimentalArchive 
```