### PR TITLE
Update logic to determine preference values

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/OONIDescriptor.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/OONIDescriptor.kt
@@ -30,17 +30,24 @@ open class OONIDescriptor<T : BaseNettest>(
 ) : Serializable, BaseDescriptor<T>(name = name, nettests = nettests) {
 
     /**
-     * Checks if any of the nettests are enabled based on the preferences stored in the provided [PreferenceManager].
+     * This function is used to determine if the current descriptor is enabled.
+     * If the descriptor is [OONITests.EXPERIMENTAL], this function returns the preference value stored for the `experimental` preference key.
+     * If the descriptor is [OONITests.WEBSITES], this function returns true if at least one category is enabled in the preferences.
+     * Otherwise, it checks if any of the nettests are enabled based on the preferences stored in the provided [PreferenceManager].
      *
      * @param preferenceManager The [PreferenceManager] instance used to resolve the status of each nettest.
      * @return Boolean Returns true if at least one nettest is enabled, false otherwise.
      */
     fun isEnabled(preferenceManager: PreferenceManager): Boolean {
-        return nettests.any {
-            preferenceManager.resolveStatus(
-                name = it.name,
-                prefix = preferencePrefix(),
-            )
+        return when (name) {
+            OONITests.EXPERIMENTAL.label -> preferenceManager.isExperimentalOn
+            OONITests.WEBSITES.label -> preferenceManager.countEnabledCategory() > 0
+            else -> nettests.any {
+                preferenceManager.resolveStatus(
+                    name = it.name,
+                    prefix = preferencePrefix(),
+                )
+            }
         }
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManagerExtension.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManagerExtension.kt
@@ -34,7 +34,20 @@ fun PreferenceManager.resolveStatus(
             resolveStatus(name = name, prefix = prefix)
         )
     } else {
-        return sp.getBoolean(getPreferenceKey(name = name, prefix = prefix), false)
+        /**
+         * If the preference key does not exist, we return the default value for the test.
+         * This is needed because ooni provided tests will not be explicitly enabled by default.
+         *
+         * However, we want to show them as enabled in the UI.
+         *
+         * Using the **[OONIDescriptor.preferencePrefix]** as an identifier, we can determine if the test is an ooni test(prefix is blank)
+         * and set the default value accordingly.
+         *
+         * The prefix is blank for ooni tests because they do not have a descriptor id.
+         * Additionally, for backward compatibility, the preference key for ooni tests
+         * is a lookup from **[PreferenceManager.getPreferenceKey]** with the test name.
+         */
+        return sp.getBoolean(getPreferenceKey(name = name, prefix = prefix), prefix.isBlank())
     }
 }
 


### PR DESCRIPTION
Fixes OONI cards not enabled by default.

## Proposed Changes

  - Set default value for ooni tests to enabled.