### PR TITLE
fix: Match result colors with descriptor theme color

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MeasurementDetailActivity.java
@@ -13,8 +13,11 @@ import androidx.appcompat.app.ActionBar;
 import androidx.fragment.app.Fragment;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import localhost.toolkit.app.fragment.ConfirmDialogFragment;
+
+import org.openobservatory.engine.BaseNettest;
 import org.openobservatory.ooniprobe.R;
 import org.openobservatory.ooniprobe.common.OONITests;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
@@ -71,15 +74,10 @@ public class MeasurementDetailActivity extends AbstractActivity implements Confi
         assert measurement != null;
         measurement.result.load();
         if (measurement.is_failed) {
-            setTheme((int) R.style.Theme_MaterialComponents_Light_DarkActionBar_App_NoActionBar_Failed);
+            setTheme(R.style.Theme_MaterialComponents_Light_DarkActionBar_App_NoActionBar_Failed);
         } else {
-            if (measurement.result.test_group_name.equals(OONITests.PERFORMANCE.getLabel())) {
-                Optional<AbstractSuite> optionalSuite = measurement.result.getTestSuite(this);
-                if (optionalSuite.isPresent()){
-                    setTheme(optionalSuite.get().getThemeLight());
-                } else {
-                    setTheme(R.style.Theme_MaterialComponents_Light_DarkActionBar_App_NoActionBar_Experimental);
-                }
+            if (Lists.transform(OONITests.PERFORMANCE.getNettests(), BaseNettest::getName).contains(measurement.test_name)) {
+                setTheme(R.style.Theme_MaterialComponents_Light_DarkActionBar_App_NoActionBar_Performance);
             } else {
                 if (measurement.is_anomaly) {
                     setTheme(R.style.Theme_MaterialComponents_Light_DarkActionBar_App_NoActionBar_Failure);

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/RunningActivity.java
@@ -32,6 +32,7 @@ import org.openobservatory.ooniprobe.test.suite.AbstractSuite;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -169,10 +170,11 @@ public class RunningActivity extends AbstractActivity implements ConfirmDialogFr
             binding.eta.setText(R.string.Dashboard_Running_CalculatingETA);
         }
 
-        if (service.task.currentSuite.getName().equals(OONITests.EXPERIMENTAL.name()))
+        if (Objects.equals(service.task.currentTest.getLabelResId(),R.string.Test_Experimental_Fullname)) {
             binding.name.setText(service.task.currentTest.getName());
-        else
+        } else {
             binding.name.setText(getString(service.task.currentTest.getLabelResId()));
+        }
         getWindow().setBackgroundDrawableResource(service.task.currentSuite.getColor());
         if (Build.VERSION.SDK_INT >= 21) {
             getWindow().setStatusBarColor(service.task.currentSuite.getColor());

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/runtests/adapter/RunTestsExpandableListViewAdapter.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/runtests/adapter/RunTestsExpandableListViewAdapter.kt
@@ -162,8 +162,8 @@ class RunTestsExpandableListViewAdapter(
 		val groupItem = getGroup(groupPosition)
 		val nettest = AbstractTest.getTestByName(childItem.name)
 		convertView.findViewById<TextView>(R.id.child_name)?.apply {
-			text = when (groupItem.name) {
-				OONITests.EXPERIMENTAL.label -> {
+			text = when (nettest.labelResId) {
+				R.string.Test_Experimental_Fullname -> {
 					childItem.name
 				}
 

--- a/app/src/main/res/layout/activity_result_detail.xml
+++ b/app/src/main/res/layout/activity_result_detail.xml
@@ -6,6 +6,7 @@
 	android:layout_height="match_parent">
 
 	<com.google.android.material.appbar.AppBarLayout
+		android:id="@+id/app_bar"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">


### PR DESCRIPTION
## Proposed Changes

  - Update `MeasurementDetailActivity` to check test names when displaying performance results.
  - Update `ResultDetailActivity` to use colour of results in themes setup and use `Experimental` test names to determine where to navigate when the measurement is clicked.
