### PR TITLE
fix: Updated `ProgressFragment` and its position on dashboard.

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/Application.java
@@ -43,7 +43,10 @@ public class Application extends android.app.Application {
 	ExecutorService executorService = Executors.newFixedThreadPool(4);
 
 	public AppComponent component;
-	@Inject AppLogger logger;
+    @Inject AppLogger logger;
+
+    @Inject
+    TestStateRepository testStateRepository;
 
 	@Override public void onCreate() {
 		super.onCreate();
@@ -116,6 +119,9 @@ public class Application extends android.app.Application {
 		return logger;
 	}
 
+    public TestStateRepository getTestStateRepository() {
+        return testStateRepository;
+    }
 	public Gson getGson() {
 		return _gson;
 	}

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/TestStateRepository.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/TestStateRepository.kt
@@ -1,0 +1,19 @@
+package org.openobservatory.ooniprobe.common
+
+import androidx.lifecycle.MutableLiveData
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * This class is used to store the state of the test group.
+ * It is used to communicate the state of the test group between the [org.openobservatory.ooniprobe.test.TestAsyncTask] and any [androidx.lifecycle.Observer].
+ *
+ * Note: Ideally, this class should used to replace Broadcasts from [org.openobservatory.ooniprobe.test.TestAsyncTask]
+ *          and "org.openobservatory.ooniprobe.activity.RunningActivity" broadcast events
+ */
+@Singleton
+class TestStateRepository @Inject constructor() {
+    var testGroupStatus = MutableLiveData(TestGroupStatus.NOT_STARTED)
+}
+
+enum class TestGroupStatus { NOT_STARTED, RUNNING, FINISHED }

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.kt
@@ -13,18 +13,18 @@ import org.openobservatory.engine.BaseNettest
 import org.openobservatory.ooniprobe.R
 import org.openobservatory.ooniprobe.activity.AbstractActivity
 import org.openobservatory.ooniprobe.activity.OverviewActivity
-import org.openobservatory.ooniprobe.activity.RunningActivity
 import org.openobservatory.ooniprobe.activity.runtests.RunTestsActivity
 import org.openobservatory.ooniprobe.adapters.DashboardAdapter
 import org.openobservatory.ooniprobe.common.Application
 import org.openobservatory.ooniprobe.common.OONIDescriptor
 import org.openobservatory.ooniprobe.common.PreferenceManager
 import org.openobservatory.ooniprobe.common.ReachabilityManager
+import org.openobservatory.ooniprobe.common.TestGroupStatus
+import org.openobservatory.ooniprobe.common.TestStateRepository
 import org.openobservatory.ooniprobe.common.ThirdPartyServices
 import org.openobservatory.ooniprobe.databinding.FragmentDashboardBinding
 import org.openobservatory.ooniprobe.fragment.dashboard.DashboardViewModel
 import org.openobservatory.ooniprobe.model.database.Result
-import org.openobservatory.ooniprobe.test.suite.AbstractSuite
 import javax.inject.Inject
 
 class DashboardFragment : Fragment(), View.OnClickListener {
@@ -33,6 +33,9 @@ class DashboardFragment : Fragment(), View.OnClickListener {
 
     @Inject
     lateinit var viewModel: DashboardViewModel
+
+    @Inject
+    lateinit var testStateRepository: TestStateRepository
 
     private var descriptors: ArrayList<OONIDescriptor<BaseNettest>> = ArrayList()
 
@@ -70,6 +73,16 @@ class DashboardFragment : Fragment(), View.OnClickListener {
             descriptors.apply {
                 clear()
                 addAll(items)
+            }
+        }
+
+        testStateRepository.testGroupStatus.observe(viewLifecycleOwner) { status ->
+            if (status == TestGroupStatus.RUNNING) {
+                binding.runAll.visibility = View.GONE
+                binding.lastTested.visibility = View.GONE
+            } else {
+                binding.runAll.visibility = View.VISIBLE
+                binding.lastTested.visibility = View.VISIBLE
             }
         }
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/ProgressFragment.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/ProgressFragment.kt
@@ -149,16 +149,20 @@ class ProgressFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
-        if (receiver.isBound) {
-            requireContext().unbindService(receiver)
-            receiver.isBound = false
+        if (::receiver.isInitialized) {
+            if (receiver.isBound) {
+                requireContext().unbindService(receiver)
+                receiver.isBound = false
+            }
+            LocalBroadcastManager.getInstance(requireContext()).unregisterReceiver(receiver)
         }
-        LocalBroadcastManager.getInstance(requireContext()).unregisterReceiver(receiver)
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        LocalBroadcastManager.getInstance(requireContext()).unregisterReceiver(receiver)
+        if (::receiver.isInitialized) {
+            LocalBroadcastManager.getInstance(requireContext()).unregisterReceiver(receiver)
+        }
     }
 
     private inner class TestRunnerEventListener : TestRunBroadRequestReceiver.EventListener {

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
@@ -23,6 +23,7 @@ import org.openobservatory.ooniprobe.common.Application;
 import org.openobservatory.ooniprobe.common.ListUtility;
 import org.openobservatory.ooniprobe.common.MKException;
 import org.openobservatory.ooniprobe.common.PreferenceManager;
+import org.openobservatory.ooniprobe.common.TestGroupStatus;
 import org.openobservatory.ooniprobe.common.ThirdPartyServices;
 import org.openobservatory.ooniprobe.common.service.RunTestService;
 import org.openobservatory.ooniprobe.common.service.ServiceUtil;
@@ -107,6 +108,7 @@ public class TestAsyncTask extends AsyncTask<Void, String, Void> implements Abst
 
     @Override
     protected Void doInBackground(Void... voids) {
+        app.getTestStateRepository().getTestGroupStatus().postValue(TestGroupStatus.RUNNING);
         if (app != null && testSuites != null) {
             registerConnChange();
             for (int suiteIdx = 0; suiteIdx < testSuites.size(); suiteIdx++) {
@@ -125,6 +127,7 @@ public class TestAsyncTask extends AsyncTask<Void, String, Void> implements Abst
                     }
                 }
             }
+            app.getTestStateRepository().getTestGroupStatus().postValue(TestGroupStatus.FINISHED);
         }
         return null;
     }

--- a/app/src/main/res/drawable/progress_blue.xml
+++ b/app/src/main/res/drawable/progress_blue.xml
@@ -2,7 +2,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 	<item android:id="@android:id/background">
 		<shape android:shape="rectangle">
-			<solid android:color="#33ffffff"/>
+			<solid android:color="@color/color_gray9"/>
 		</shape>
 	</item>
 	<item android:id="@android:id/secondaryProgress">

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,12 +11,6 @@
 		android:layout_height="0dp"
 		android:layout_weight="1"/>
 
-	<fragment
-		android:name="org.openobservatory.ooniprobe.fragment.ProgressFragment"
-		android:id="@+id/progress_fragment"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content" />
-
 	<com.google.android.material.bottomnavigation.BottomNavigationView
 		android:id="@+id/bottomNavigation"
 		android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_measurement_detail.xml
+++ b/app/src/main/res/layout/activity_measurement_detail.xml
@@ -103,12 +103,4 @@
 				android:padding="16dp" />
 		</LinearLayout>
 	</ScrollView>
-
-	<fragment
-		android:name="org.openobservatory.ooniprobe.fragment.ProgressFragment"
-		android:id="@+id/progress_fragment"
-		android:layout_gravity="bottom"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content" />
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_overview.xml
+++ b/app/src/main/res/layout/activity_overview.xml
@@ -177,12 +177,4 @@
                 app:layout_constraintTop_toBottomOf="@id/header" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
-
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/progress_fragment"
-        android:name="org.openobservatory.ooniprobe.fragment.ProgressFragment"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
-        app:layout_anchorGravity="bottom" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_result_detail.xml
+++ b/app/src/main/res/layout/activity_result_detail.xml
@@ -70,11 +70,4 @@
 		android:id="@+id/snackbarAnchor"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"/>
-	<fragment
-		android:name="org.openobservatory.ooniprobe.fragment.ProgressFragment"
-		android:id="@+id/progress_fragment"
-		android:layout_gravity="bottom"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content" />
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>    <!-- app:layout_scrollFlags="scroll|exitUntilCollapsed|snap" -->

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -46,37 +46,53 @@
 
 	</com.github.florent37.shapeofview.shapes.ArcView>
 
-	<Button
-		android:id="@+id/run_all"
-		android:textAppearance="?attr/textAppearanceHeadline6"
-		android:layout_width="wrap_content"
-		android:layout_height="56dp"
+	<LinearLayout
+		android:id="@+id/idle_layout"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
 		android:layout_marginTop="24dp"
-		android:stateListAnimator="@null"
-		android:elevation="5dp"
-		android:translationZ="5dp"
-		android:text="@string/Dashboard_Card_Run"
-		android:textAllCaps="false"
-		android:transitionName="@string/transitionNameRun"
-		android:drawableEnd="@drawable/outline_timer"
-		android:drawableTint="@android:color/white"
+		android:paddingStart="14dp"
+		android:paddingEnd="14dp"
+		android:gravity="center"
+		android:orientation="vertical"
 		app:layout_constraintTop_toTopOf="@id/arc_view"
 		app:layout_constraintEnd_toEndOf="@id/arc_view"
-		app:layout_constraintStart_toStartOf="@id/arc_view"
-		app:layout_constraintBottom_toBottomOf="@id/arc_view"
-		app:cornerRadius="24dp"
-		app:rippleColor="@color/ripple_material_light" />
+		app:layout_constraintStart_toStartOf="@id/arc_view">
 
-	<TextView
-		android:id="@+id/last_tested"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:text="@string/Dashboard_Overview_LatestTest"
-		app:layout_constraintStart_toStartOf="parent"
-		app:layout_constraintEnd_toEndOf="parent"
-		app:layout_constraintTop_toBottomOf="@id/run_all"
-		android:textAppearance="?attr/textAppearanceCaption"
-		android:textColor="@color/color_black"/>
+		<Button
+			android:id="@+id/run_all"
+			android:textAppearance="?attr/textAppearanceHeadline6"
+			android:layout_width="wrap_content"
+			android:layout_height="56dp"
+			android:stateListAnimator="@null"
+			android:elevation="5dp"
+			android:translationZ="5dp"
+			android:text="@string/Dashboard_Card_Run"
+			android:textAllCaps="false"
+			android:transitionName="@string/transitionNameRun"
+			android:drawableEnd="@drawable/outline_timer"
+			android:drawableTint="@android:color/white"
+			app:layout_constraintBottom_toBottomOf="@id/arc_view"
+			app:cornerRadius="24dp"
+			app:rippleColor="@color/ripple_material_light"
+			android:visibility="gone"/>
+
+		<TextView
+			android:id="@+id/last_tested"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:text="@string/Dashboard_Overview_LatestTest"
+			android:textAppearance="?attr/textAppearanceCaption"
+			android:textColor="@color/color_black"
+			android:visibility="gone"/>
+
+		<fragment
+			android:name="org.openobservatory.ooniprobe.fragment.ProgressFragment"
+			android:id="@+id/progress_fragment"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="18dp"/>
+	</LinearLayout>
 
 	<RelativeLayout
 		android:id="@+id/vpnLayout"
@@ -85,8 +101,7 @@
 		android:layout_margin="8dp"
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintEnd_toEndOf="parent"
-		app:layout_constraintTop_toBottomOf="@id/last_tested">
-
+		app:layout_constraintTop_toBottomOf="@id/idle_layout">
 		<TextView
 			android:id="@+id/vpn"
 			app:drawableStartCompat="@android:drawable/ic_dialog_alert"

--- a/app/src/main/res/layout/fragment_progress.xml
+++ b/app/src/main/res/layout/fragment_progress.xml
@@ -1,54 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:app="http://schemas.android.com/apk/res-auto"
-	xmlns:tools="http://schemas.android.com/tools"
-	android:id="@+id/progress_layout"
-	android:layout_width="match_parent"
-	android:layout_height="match_parent"
-	android:background="@color/progress_background"
-	tools:context=".fragment.ProgressFragment">
-	<LinearLayout
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:orientation="vertical">
-		<ProgressBar
-			android:id="@+id/progress"
-			style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-			android:minHeight="8dp"
-			android:maxHeight="8dp"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:progressDrawable="@drawable/progress_blue"
-			android:indeterminateTint="@color/color_base"/>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/progress_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".fragment.ProgressFragment">
 
-		<LinearLayout
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"
-			android:layout_marginStart="20dp"
-			android:layout_marginTop="20dp"
-			android:layout_marginBottom="20dp"
-			android:orientation="horizontal">
 
-			<ImageView
-				android:id="@+id/test_image"
-				android:layout_width="wrap_content"
-				android:layout_height="match_parent"
-				android:contentDescription="@string/OONIRun_TestName"
-				android:src="@null"
-				app:tint="@color/color_white"
-				android:visibility="gone"
-				tools:ignore="RtlSymmetry"/>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginBottom="8dp"
+        android:gravity="center_horizontal"
+        android:orientation="horizontal">
 
-			<TextView
-				android:id="@+id/name"
-				style="@style/TextAppearance.AppCompat.Small"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:gravity="center_vertical"
-				android:textColor="@color/color_white"
-				android:text="@string/Dashboard_Running_PreparingTest"/>
-		</LinearLayout>
-	</LinearLayout>
+        <ImageView
+            android:id="@+id/test_image"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:contentDescription="@string/OONIRun_TestName"
+            android:src="@null"
+            android:visibility="gone"
+            app:tint="@color/color_gray9"
+            tools:ignore="RtlSymmetry" />
 
-</FrameLayout>
+        <TextView
+            android:id="@+id/name"
+            style="@style/TextAppearance.AppCompat.Small"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:text="@string/Dashboard_Running_PreparingTest"
+            android:textColor="@color/color_gray9" />
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/progress"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminateTint="@color/color_base"
+        android:maxHeight="8dp"
+        android:minHeight="8dp"
+        android:progressDrawable="@drawable/progress_blue" />
+
+</LinearLayout>


### PR DESCRIPTION
## Proposed Changes

  - Update `ProgressFragment` to match design spec.
  - Introduce `TestStateRepository` to reliably store the state of the running test (UI not currently displayed cannot receive events from BroadcasrReciever).
  - Update `DashboardFragment` to replace `run` button with `ProgressFragment`  when tests are running.

| Dark Mode with `vpn` banner| Light Mode with `vpn` banner|
|-|-|
| ![Screenshot_20240226_123849](https://github.com/ooni/probe-android/assets/17911892/8496ea6e-40ab-4510-a218-0773211f6eee) | ![Screenshot_20240226_124029](https://github.com/ooni/probe-android/assets/17911892/c0df87d8-6c37-4592-8cd7-503f52d34c84) |
| Dark mode with no `vpn` | Light mode with no `vpn` |
| ![Screenshot_20240226_124728](https://github.com/ooni/probe-android/assets/17911892/bf981e43-bcf5-442e-9df4-03bffd952176) | ![Screenshot_20240226_124747](https://github.com/ooni/probe-android/assets/17911892/28fb6bd5-4bc4-4501-9afb-e0b6f99393bd) |
