### PR TITLE
feat: (OONI Run v2) Web connectivity tests always appears selected, even if deselected

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/adapters/DashboardAdapter.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/adapters/DashboardAdapter.kt
@@ -63,30 +63,14 @@ class DashboardAdapter(
                             if (item is InstalledDescriptor){
                                 icon.setColorFilter(item.color)
                             }
-                        }                    }
-                    holder.itemView.tag = item
-                    if (!item.isEnabled(preferenceManager)) {
-                        holder.setIsRecyclable(false)
-                        holder.itemView.apply {
-                            elevation = 0f
-                            isClickable = false
                         }
-                        val resources: Resources = holder.itemView.context.resources
-                        (holder.itemView as CardView).setCardBackgroundColor(resources.getColor(R.color.disabled_test_background))
-                        holder.binding.apply {
-                            title.setTextColor(resources.getColor(R.color.disabled_test_text))
-                            desc.setTextColor(resources.getColor(R.color.disabled_test_text))
-                            icon.setColorFilter(
-                                resources.getColor(R.color.disabled_test_text),
-                                PorterDuff.Mode.SRC_IN
-                            )
-                        }
-                    } else {
-                        holder.itemView.setOnClickListener(onClickListener)
                     }
+                    holder.itemView.tag = item
+                    holder.itemView.setOnClickListener(onClickListener)
                 }
             }
         }
+        holder.setIsRecyclable(false)
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/OONIDescriptor.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/OONIDescriptor.kt
@@ -45,7 +45,6 @@ abstract class AbstractDescriptor<T : BaseNettest>(
     open fun isEnabled(preferenceManager: PreferenceManager): Boolean {
         return when (name) {
             OONITests.EXPERIMENTAL.label -> preferenceManager.isExperimentalOn
-            OONITests.WEBSITES.label -> preferenceManager.countEnabledCategory() > 0
             else -> nettests.any {
                 preferenceManager.resolveStatus(
                     name = it.name,
@@ -120,7 +119,6 @@ abstract class AbstractDescriptor<T : BaseNettest>(
                 ChildItem(
                     selected = when (name) {
                         OONITests.EXPERIMENTAL.label -> preferenceManager.isExperimentalOn
-                        OONITests.WEBSITES.label -> preferenceManager.countEnabledCategory() > 0
                         else -> preferenceManager.resolveStatus(
                             name = nettest.name,
                             prefix = preferencePrefix(),

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManagerExtension.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManagerExtension.kt
@@ -24,9 +24,7 @@ fun PreferenceManager.resolveStatus(
     name: String, prefix: String, autoRun: Boolean = false
 ): Boolean {
     if (!autoRun) {
-        if (name == WebConnectivity.NAME) {
-            return true
-        } else if (experimentalTestList().contains(name)) {
+        if (experimentalTestList().contains(name)) {
             return isExperimentalOn
         }
     }
@@ -79,7 +77,6 @@ private fun PreferenceManager.setValue(
     if (experimentalTestList().contains(name) && !autoRun) {
         return false
     }
-    val key = getPreferenceKey(name = name, prefix = prefix, autoRun = autoRun)
 
     return with(sp.edit()) {
         putBoolean(getPreferenceKey(name = name, prefix = prefix, autoRun = autoRun), value)

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/dashboard/DashboardViewModel.kt
@@ -50,8 +50,7 @@ class DashboardViewModel @Inject constructor(
 
     private fun fetchItemList() {
 
-        val groupedItems = items.value!!.sortedBy { !it.isEnabled(preferenceManager) }
-            .groupBy {
+        val groupedItems = items.value!!.groupBy {
                 return@groupBy if (oonTests.contains(it)) {
                     oonTestsTitle
                 } else {


### PR DESCRIPTION
- Fixes https://github.com/ooni/run/issues/141 , https://github.com/ooni/run/issues/143

## Proposed Changes

  - Remove `isEnabled` from the dashboard.
  - Change `OONITests.WEBSITES` preferences
