### PR TITLE
chore (OONI Run V2): Add missing error message when no tests are selected

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/runtests/RunTestsActivity.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/runtests/RunTestsActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import org.openobservatory.engine.BaseNettest
@@ -103,6 +104,8 @@ class RunTestsActivity : AbstractActivity() {
                 { finish() },
                 preferenceManager
             )
+        } else {
+			Toast.makeText(this@RunTestsActivity, "Please select test to run", Toast.LENGTH_LONG).show()
         }
     }
 


### PR DESCRIPTION
- Fixes  https://github.com/ooni/run/issues/142

## Proposed Changes

  - Add `Toast` where no test is selected
 
|.|.|
|-|-|
| ![Screenshot_20240320_173337](https://github.com/ooni/probe-android/assets/17911892/ee2bb49d-7411-4807-91b0-1a2445aa5ba4) | ![Screenshot_20240320_173411](https://github.com/ooni/probe-android/assets/17911892/b4c4986a-f608-483a-b8c4-4223e9892f4b) |
