### PR TITLE
feat(OONI Run v2): Filter out expired tests when launching `RunTestsActivity`

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/runtests/RunTestsActivity.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/runtests/RunTestsActivity.kt
@@ -23,6 +23,7 @@ import org.openobservatory.ooniprobe.common.PreferenceManager
 import org.openobservatory.ooniprobe.common.disableTest
 import org.openobservatory.ooniprobe.common.enableTest
 import org.openobservatory.ooniprobe.databinding.ActivityRunTestsBinding
+import org.openobservatory.ooniprobe.model.database.InstalledDescriptor
 import java.io.Serializable
 import javax.inject.Inject
 
@@ -40,13 +41,25 @@ class RunTestsActivity : AbstractActivity() {
 	companion object {
 		const val TESTS: String = "tests"
 
+        /**
+         * Create a new intent to start the [RunTestsActivity].
+         * @param context The context from which the activity is started.
+         * @param testSuites The list of test suites to run.
+         * @return The intent to start the [RunTestsActivity] with unexpired descriptors.
+         */
         @JvmStatic
         fun newIntent(context: Context, testSuites: List<AbstractDescriptor<BaseNettest>>): Intent {
             return Intent(context, RunTestsActivity::class.java).putExtras(Bundle().apply {
-                putSerializable(TESTS, testSuites as Serializable)
+                putSerializable(TESTS, testSuites.filter {
+                    if (it is InstalledDescriptor) {
+                        return@filter it.descriptor?.isExpired == false
+                    } else {
+                        return@filter true
+                    }
+                } as Serializable)
             })
         }
-	}
+    }
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)


### PR DESCRIPTION
Fixes https://github.com/ooni/run/issues/161

## Proposed Changes

  - Filter out expired tests when launching `RunTestsActivity`

|.|.|
|-|-|
| ![Screenshot_20240411_081232](https://github.com/ooni/probe-android/assets/17911892/2ffc19b1-08c7-4dcd-9bc0-914171c747c1) | ![Screenshot_20240411_081249](https://github.com/ooni/probe-android/assets/17911892/9e07f07d-e3ce-4674-b20d-a36a998c7d01) |

