### PR TITLE
feat (OONI Run v2): Add support for updated badge

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ android {
         stable {
             dimension 'testing'
             buildConfigField 'String', 'BASE_SOFTWARE_NAME', '"ooniprobe-android"'
+            buildConfigField 'String', 'OONI_API_BASE_URL', '"https://api.dev.ooni.io"'
         }
         dev {
             dimension 'testing'

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/MainActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/MainActivity.java
@@ -32,6 +32,7 @@ import androidx.work.WorkManager;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.openobservatory.ooniprobe.R;
+import org.openobservatory.ooniprobe.activity.reviewdescriptorupdates.AvailableUpdatesViewModel;
 import org.openobservatory.ooniprobe.activity.reviewdescriptorupdates.ReviewDescriptorUpdatesActivity;
 import org.openobservatory.ooniprobe.common.Application;
 import org.openobservatory.ooniprobe.common.NotificationUtility;
@@ -74,6 +75,9 @@ public class MainActivity extends ReviewUpdatesAbstractActivity implements Confi
 
     @Inject
     TestDescriptorManager descriptorManager;
+
+    @Inject
+    AvailableUpdatesViewModel updatesViewModel;
 
     private ActivityResultLauncher<String> requestPermissionLauncher;
 
@@ -213,7 +217,7 @@ public class MainActivity extends ReviewUpdatesAbstractActivity implements Confi
      */
     private void onManualUpdatesFetchComplete(WorkInfo workInfo) {
         if (workInfo != null) {
-            if (workInfo.getProgress().getInt(PROGRESS,-1) >= 0) {
+            if (workInfo.getProgress().getInt(PROGRESS, -1) >= 0) {
                 binding.reviewUpdateNotificationFragment.setVisibility(View.VISIBLE);
             }
             switch (workInfo.getState()) {
@@ -224,29 +228,32 @@ public class MainActivity extends ReviewUpdatesAbstractActivity implements Confi
                         return;
                     }
                     getSupportFragmentManager()
-                        .beginTransaction()
-                        .add(
-                            R.id.review_update_notification_fragment,
-                            OONIRunDynamicProgressBar.newInstance(ProgressType.REVIEW_LINK, new OnActionListener() {
-                                @Override
-                                public void onActionButtonCLicked() {
+                            .beginTransaction()
+                            .add(
+                                    R.id.review_update_notification_fragment,
+                                    OONIRunDynamicProgressBar.newInstance(ProgressType.REVIEW_LINK, new OnActionListener() {
+                                        @Override
+                                        public void onActionButtonCLicked() {
 
-                                    getReviewUpdatesLauncher().launch(
-                                        ReviewDescriptorUpdatesActivity.newIntent(
-                                            MainActivity.this,
-                                            descriptor
-                                        )
-                                    );
-                                    removeProgressFragment(R.id.review_update_notification_fragment);
-                                }
+                                            getReviewUpdatesLauncher().launch(
+                                                    ReviewDescriptorUpdatesActivity.newIntent(
+                                                            MainActivity.this,
+                                                            descriptor,
+                                                            true
+                                                    )
+                                            );
+                                            removeProgressFragment(R.id.review_update_notification_fragment);
+                                        }
 
-                                @Override
-                                public void onCloseButtonClicked() {
-                                    removeProgressFragment(R.id.review_update_notification_fragment);
-                                }
-                            }),
-                            OONIRunDynamicProgressBar.getTAG() + "_review_update_success_notification"
-                        ).commit();
+                                        @Override
+                                        public void onCloseButtonClicked() {
+                                            updatesViewModel.setDescriptorsWith(descriptor);
+                                            //TODO: Add a method to reload the list of descriptors.
+                                            removeProgressFragment(R.id.review_update_notification_fragment);
+                                        }
+                                    }),
+                                    OONIRunDynamicProgressBar.getTAG() + "_review_update_success_notification"
+                            ).commit();
                 }
 
                 case ENQUEUED -> getSupportFragmentManager()
@@ -321,11 +328,11 @@ public class MainActivity extends ReviewUpdatesAbstractActivity implements Confi
                 binding.bottomNavigation.setSelectedItemId(intent.getIntExtra(RES_ITEM, R.id.dashboard));
             } else if (intent.getExtras().containsKey(NOTIFICATION_DIALOG)) {
                 new ConfirmDialogFragment.Builder()
-                    .withTitle(intent.getExtras().getString("title"))
-                    .withMessage(intent.getExtras().getString("message"))
-                    .withNegativeButton("")
-                    .withPositiveButton(getString(R.string.Modal_OK))
-                    .build().show(getSupportFragmentManager(), null);
+                        .withTitle(intent.getExtras().getString("title"))
+                        .withMessage(intent.getExtras().getString("message"))
+                        .withNegativeButton("")
+                        .withPositiveButton(getString(R.string.Modal_OK))
+                        .build().show(getSupportFragmentManager(), null);
             }
         }
     }

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/OverviewActivity.java
@@ -35,6 +35,7 @@ import org.openobservatory.ooniprobe.activity.customwebsites.CustomWebsiteActivi
 import org.openobservatory.ooniprobe.activity.overview.OverviewTestsExpandableListViewAdapter;
 import org.openobservatory.ooniprobe.activity.overview.OverviewViewModel;
 import org.openobservatory.ooniprobe.activity.overview.RevisionsFragment;
+import org.openobservatory.ooniprobe.activity.reviewdescriptorupdates.AvailableUpdatesViewModel;
 import org.openobservatory.ooniprobe.activity.reviewdescriptorupdates.ReviewDescriptorUpdatesActivity;
 import org.openobservatory.ooniprobe.common.AbstractDescriptor;
 import org.openobservatory.ooniprobe.common.OONITests;
@@ -66,6 +67,10 @@ public class OverviewActivity extends ReviewUpdatesAbstractActivity implements C
 
     @Inject
     OverviewViewModel viewModel;
+
+
+    @Inject
+    AvailableUpdatesViewModel updatesViewModel;
 
     OverviewTestsExpandableListViewAdapter adapter;
 
@@ -111,6 +116,22 @@ public class OverviewActivity extends ReviewUpdatesAbstractActivity implements C
                 );
                 if (Boolean.TRUE.equals(testDescriptor.isExpired())) {
                     binding.expiredTag.getRoot().setVisibility(View.VISIBLE);
+                }
+
+                InstalledDescriptor installedDescriptor = ((InstalledDescriptor) descriptor);
+                if (installedDescriptor.isUpdateAvailable()) {
+                    binding.updatedTag.getRoot().setVisibility(View.VISIBLE);
+
+
+                    binding.reviewUpdates.setVisibility(View.VISIBLE);
+                    binding.reviewUpdates.setOnClickListener(view -> getReviewUpdatesLauncher().launch(
+                            ReviewDescriptorUpdatesActivity.newIntent(
+                                    OverviewActivity.this,
+                                    updatesViewModel.getUpdatedDescriptor(testDescriptor.getRunId())
+                            )
+                    ));
+
+
                 }
             } else {
                 markwon.setMarkdown(binding.desc, descriptor.getDescription());

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/adddescriptor/AddDescriptorActivity.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/adddescriptor/AddDescriptorActivity.kt
@@ -89,7 +89,9 @@ class AddDescriptorActivity : AbstractActivity() {
                     StringUtils.camelToSnake(
                         iconName
                     ), "drawable", imageView.context.packageName
-                )
+                ).let {
+                    if (it == 0) R.drawable.ooni_empty_state else it
+                }
             ).apply {
                 color?.let {
                     imageView.setColorFilter(it)

--- a/app/src/main/java/org/openobservatory/ooniprobe/activity/reviewdescriptorupdates/AvailableUpdatesViewModel.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/activity/reviewdescriptorupdates/AvailableUpdatesViewModel.kt
@@ -1,0 +1,23 @@
+package org.openobservatory.ooniprobe.activity.reviewdescriptorupdates
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.google.gson.Gson
+import org.openobservatory.ooniprobe.model.database.ITestDescriptor
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AvailableUpdatesViewModel @Inject() constructor(var gson: Gson) : ViewModel() {
+    var descriptors: MutableLiveData<List<ITestDescriptor>> = MutableLiveData()
+    var descriptorString: MutableLiveData<String> = MutableLiveData()
+
+    fun setDescriptorsWith(descriptorJson: String) {
+        descriptorString.value = descriptorJson
+        descriptors.value = gson.fromJson(descriptorJson, Array<ITestDescriptor>::class.java).toList()
+    }
+
+    fun getUpdatedDescriptor(runId: Long): String {
+        return gson.toJson(arrayOf(descriptors.value?.find { it.runId == runId }))
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/adapters/DashboardAdapter.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/adapters/DashboardAdapter.kt
@@ -9,7 +9,6 @@ import org.openobservatory.ooniprobe.common.PreferenceManager
 import org.openobservatory.ooniprobe.databinding.ItemSeperatorBinding
 import org.openobservatory.ooniprobe.databinding.ItemTestsuiteBinding
 import org.openobservatory.ooniprobe.model.database.InstalledDescriptor
-import java.util.Date
 
 class DashboardAdapter(
     private val items: List<Any>,
@@ -46,9 +45,9 @@ class DashboardAdapter(
         val item = items[position]
         when (holder.itemViewType) {
             VIEW_TYPE_TITLE -> {
-				val separator = holder as CardGroupTitleViewHolder
-				separator.binding.root.text = item as String
-			}
+                val separator = holder as CardGroupTitleViewHolder
+                separator.binding.root.text = item as String
+            }
 
             VIEW_TYPE_CARD -> {
                 val cardHolder = holder as CardViewHolder
@@ -57,10 +56,14 @@ class DashboardAdapter(
                         title.setText(item.title)
                         desc.setText(item.shortDescription)
                         icon.setImageResource(item.getDisplayIcon(holder.itemView.context)).also {
-                            if (item is InstalledDescriptor){
+                            if (item is InstalledDescriptor) {
                                 icon.setColorFilter(item.color)
                                 if (item.descriptor?.isExpired == true) {
                                     expiredTag.root.visibility = View.VISIBLE
+                                } else if (item.tags?.isNotEmpty() == true && item.tags?.get(0) == "updated") {
+                                    updatedTag.root.visibility = View.VISIBLE
+                                } else {
+                                    expiredTag.root.visibility = View.GONE
                                 }
                                 holder.setIsRecyclable(false)
                             }

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/DashboardFragment.kt
@@ -14,6 +14,7 @@ import org.openobservatory.ooniprobe.R
 import org.openobservatory.ooniprobe.activity.AbstractActivity
 import org.openobservatory.ooniprobe.activity.MainActivity
 import org.openobservatory.ooniprobe.activity.OverviewActivity
+import org.openobservatory.ooniprobe.activity.reviewdescriptorupdates.AvailableUpdatesViewModel
 import org.openobservatory.ooniprobe.activity.runtests.RunTestsActivity
 import org.openobservatory.ooniprobe.adapters.DashboardAdapter
 import org.openobservatory.ooniprobe.common.AbstractDescriptor
@@ -36,8 +37,12 @@ class DashboardFragment : Fragment(), View.OnClickListener {
     lateinit var viewModel: DashboardViewModel
 
     private var descriptors: ArrayList<AbstractDescriptor<BaseNettest>> = ArrayList()
+
     @Inject
     lateinit var testStateRepository: TestStateRepository
+
+    @Inject
+    lateinit var updatesViewModel: AvailableUpdatesViewModel
 
     private lateinit var binding: FragmentDashboardBinding
 
@@ -90,6 +95,10 @@ class DashboardFragment : Fragment(), View.OnClickListener {
         binding.swipeRefresh.setOnRefreshListener {
             (requireActivity() as MainActivity).fetchManualUpdate()
             binding.swipeRefresh.isRefreshing = false
+        }
+
+        updatesViewModel.descriptors.observe(viewLifecycleOwner) { descriptors ->
+            descriptors.let { viewModel.updateDescriptorWith(it) }
         }
     }
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/fragment/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/fragment/dashboard/DashboardViewModel.kt
@@ -9,13 +9,16 @@ import org.openobservatory.engine.BaseNettest
 import org.openobservatory.ooniprobe.common.AbstractDescriptor
 import org.openobservatory.ooniprobe.common.PreferenceManager
 import org.openobservatory.ooniprobe.common.TestDescriptorManager
+import org.openobservatory.ooniprobe.model.database.ITestDescriptor
 import org.openobservatory.ooniprobe.model.database.InstalledDescriptor
+import org.openobservatory.ooniprobe.model.database.TestDescriptor
 import javax.inject.Inject
 
 class DashboardViewModel @Inject constructor(
-    private val preferenceManager: PreferenceManager,
-    private val descriptorManager: TestDescriptorManager
+        private val preferenceManager: PreferenceManager,
+        private val descriptorManager: TestDescriptorManager
 ) : ViewModel(), DefaultLifecycleObserver {
+    private var pendingUpdates: MutableLiveData<List<ITestDescriptor>> = MutableLiveData()
     private var ooniRunDescriptors: List<InstalledDescriptor> = emptyList()
     private val oonTestsTitle: String = "OONI Tests"
     private val oonRunLinksTitle: String = "OONI RUN Links"
@@ -25,14 +28,24 @@ class DashboardViewModel @Inject constructor(
 
     init {
         ooniRunDescriptors = descriptorManager.getRunV2Descriptors().map {
-            InstalledDescriptor(it)
+            InstalledDescriptor(it, getTags(it))
+        }
+    }
+
+    private fun getTags(descriptor: TestDescriptor): List<String> {
+        pendingUpdates.value.let { updates ->
+            return if (updates?.any { it.runId == descriptor.runId } == true) {
+                listOf("updated")
+            } else {
+                emptyList()
+            }
         }
     }
 
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         ooniRunDescriptors = descriptorManager.getRunV2Descriptors().map {
-            InstalledDescriptor(it)
+            InstalledDescriptor(it, getTags(it))
         }
         fetchItemList()
     }
@@ -51,12 +64,12 @@ class DashboardViewModel @Inject constructor(
     private fun fetchItemList() {
 
         val groupedItems = items.value!!.groupBy {
-                return@groupBy if (oonTests.contains(it)) {
-                    oonTestsTitle
-                } else {
-                    ""
-                }
+            return@groupBy if (oonTests.contains(it)) {
+                oonTestsTitle
+            } else {
+                ""
             }
+        }
 
         val groupedItemList = mutableListOf<Any>()
         groupedItems.forEach { (status, itemList) ->
@@ -68,5 +81,13 @@ class DashboardViewModel @Inject constructor(
             groupedItemList.addAll(ooniRunDescriptors)
         }
         this.groupedItemList.value = groupedItemList
+    }
+
+    fun updateDescriptorWith(descriptors: List<ITestDescriptor>) {
+        pendingUpdates.value = descriptors
+        ooniRunDescriptors = descriptorManager.getRunV2Descriptors().map {
+            InstalledDescriptor(it, getTags(it))
+        }
+        fetchItemList()
     }
 }

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Result.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Result.java
@@ -239,7 +239,7 @@ public class Result extends BaseModel implements Serializable {
              * We return an {@link InstalledDescriptor} object which implements {@link AbstractDescriptor}.
              */
             if (descriptor != null) {
-                return Optional.of(new InstalledDescriptor(descriptor));
+                return Optional.of(new InstalledDescriptor(descriptor, null));
             }
             /**
              * If the descriptor does not exist, then this is an OONI Provided test or an OONI Run v1 measurement result.

--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/TestDescriptor.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/TestDescriptor.kt
@@ -105,7 +105,8 @@ fun TestDescriptor.shouldUpdate(updatedDescriptor: TestDescriptor): Boolean {
 private const val DESCRIPTOR_TEST_NAME = "ooni_run"
 
 class InstalledDescriptor(
-    var testDescriptor: TestDescriptor
+    var testDescriptor: TestDescriptor,
+    var tags: List<String>? = null
 ) : AbstractDescriptor<BaseNettest>(
     name = DESCRIPTOR_TEST_NAME,
     title = testDescriptor.name,
@@ -131,6 +132,10 @@ class InstalledDescriptor(
 
     override fun getRuntime(context: Context, preferenceManager: PreferenceManager): Int {
         return R.string.TestResults_NotAvailable
+    }
+
+    fun isUpdateAvailable(): Boolean {
+        return tags?.contains("updated") ?: false
     }
 
     override fun toRunTestsGroupItem(preferenceManager: PreferenceManager): GroupItem {

--- a/app/src/main/res/drawable/warning_amber.xml
+++ b/app/src/main/res/drawable/warning_amber.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,5.99L19.53,19H4.47L12,5.99M12,2L1,21h22L12,2L12,2z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M13,16l-2,0l0,2l2,0z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M13,10l-2,0l0,5l2,0z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_overview.xml
+++ b/app/src/main/res/layout/activity_overview.xml
@@ -32,6 +32,16 @@
                     android:paddingBottom="16dp"
                     app:layout_collapseMode="parallax">
 
+
+                    <include
+                        android:id="@+id/updated_tag"
+                        layout="@layout/updated_tag"
+                        android:visibility="gone"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/item_padding_large"
+                        android:layout_marginBottom="@dimen/item_padding_large" />
+
                     <ImageView
                         android:id="@+id/icon"
                         android:layout_width="96dp"

--- a/app/src/main/res/layout/item_testsuite.xml
+++ b/app/src/main/res/layout/item_testsuite.xml
@@ -77,6 +77,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/item_padding_large"/>
 
+            <include
+                android:id="@+id/updated_tag"
+                layout="@layout/updated_tag"
+                android:visibility="gone"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/item_padding_large"/>
+
             <ImageView
                 android:layout_width="20dp"
                 android:layout_height="20dp"

--- a/app/src/main/res/layout/updated_tag.xml
+++ b/app/src/main/res/layout/updated_tag.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="4dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/color_red7"
+        android:paddingVertical="4dp"
+        android:paddingHorizontal="6dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="UPDATED"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            android:textColor="@android:color/white"/>
+
+        <ImageView
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:paddingStart="4dp"
+            app:tintMode="@color/color_red7"
+            android:src="@drawable/warning_amber" />
+    </LinearLayout>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION

## Proposed Changes
- Introduce `AvailableUpdatesViewModel` to store cancelled updates across the application instance.
- Show the `updated` badge based on the availability of the descriptor in `AvailableUpdatesViewModel`

|.|.|
|-|-|
| ![Screenshot_20240508_090940](https://github.com/ooni/probe-android/assets/17911892/fffe9487-5836-4742-a571-d8530ed3d647) | ![Screenshot_20240508_090952](https://github.com/ooni/probe-android/assets/17911892/c4b990ed-8cdc-4635-a637-6349a71e9356) |
