### PR TITLE
PoC: save URLs in status.measurement_started

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/model/database/Url.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/model/database/Url.java
@@ -88,7 +88,6 @@ public class Url extends BaseModel implements Serializable {
 	 * @return list of url strings.
 	 */
 	public static List<String> saveOrUpdate(List<Url> urls) {
-
 		Map<String, Url> resultUrlsMap = Maps.uniqueIndex(
 				urls,
 				input -> input.url
@@ -131,7 +130,6 @@ public class Url extends BaseModel implements Serializable {
 			List<Url> urlsToSave = Lists.transform(Lists.newArrayList(newUrlSet), resultUrlsMap::get);
 
 			Url.saveAll(urlsToSave);
-
 		}
 
 		return new ArrayList<>(resultUrlsMap.keySet());

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java
@@ -147,7 +147,6 @@ public class TestAsyncTask extends AsyncTask<Void, String, Void> implements Abst
                 }
                 if (!interrupt) {
                     Log.d(TAG, "run next suite: " + currentSuite.getName() + " test:" + currentTest.getName());
-
                     currentTest.run(app, app.getPreferenceManager(),app.getLogger(), app.getGson(), result, i, this);
                 }
             }
@@ -159,6 +158,7 @@ public class TestAsyncTask extends AsyncTask<Void, String, Void> implements Abst
     }
 
     //This uses the wrapper
+    // TODO(bassosimone): I am not sure of the meaning of the comment above.
     private void downloadURLs() {
         try {
             OONISession session = EngineProvider.get().newSession(
@@ -192,7 +192,16 @@ public class TestAsyncTask extends AsyncTask<Void, String, Void> implements Abst
                 webConnectivity.getUrls(),
                 url -> new Url(url.getUrl(), url.getCategoryCode(), url.getCountryCode())
             );
-            List<String> inputs = Url.saveOrUpdate(urls);
+
+            // TODO(bassosimone): we obviously need to refactor/rename this function
+            // and modify the code more extensively than we're doing right now.
+            //
+            // The next step is to take advantage of the probe engine fetching the URLs
+            // however for now oonimkall does not do that yet.
+            List<String> inputs = new ArrayList<>();
+            for (var url : urls) {
+                inputs.add(url.url);
+            }
 
             currentTest.setInputs(inputs);
 

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/suite/AbstractSuite.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/suite/AbstractSuite.java
@@ -163,5 +163,4 @@ public abstract class AbstractSuite implements Serializable {
 				}
 		return null;
 	}
-
 }


### PR DESCRIPTION
This PoC should show that we can save measurements in the status.measurement_started callback. Obviously, a complete diff for probe-android should be more comprehensive and TBH my aim here is just to show it is *possible*.

Related to https://github.com/ooni/probe/issues/2752.