### PR TITLE
Replace writeStringToFile,readFileToString with some kotlin extensions

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/ResubmitTask.java
@@ -10,7 +10,7 @@ import androidx.annotation.VisibleForTesting;
 
 import com.raizlabs.android.dbflow.sql.language.Where;
 
-import org.apache.commons.io.FileUtils;
+import org.openobservatory.ooniprobe.kt.FileUtils;
 import org.openobservatory.engine.LoggerArray;
 import org.openobservatory.engine.OONIContext;
 import org.openobservatory.engine.OONISession;
@@ -74,9 +74,9 @@ public class ResubmitTask<A extends AbstractActivity> extends NetworkProgressAsy
         long uploadTimeout = getTimeout(file.length());
         OONIContext ooniContext = session.newContextWithTimeout(uploadTimeout);
         try {
-            input = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+            input = FileUtils.Companion.readFileToString(file, StandardCharsets.UTF_8);
             OONISubmitResults results = session.submit(ooniContext, input);
-            FileUtils.writeStringToFile(file, results.getUpdatedMeasurement(), StandardCharsets.UTF_8);
+            FileUtils.Companion.writeStringToFile(file, results.getUpdatedMeasurement(), StandardCharsets.UTF_8 , /*append*/ false);
             m.report_id = results.getUpdatedReportID();
             m.deleteReportFile(c);
             m.is_uploaded = true;

--- a/app/src/main/java/org/openobservatory/ooniprobe/domain/MeasurementsManager.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/domain/MeasurementsManager.java
@@ -6,7 +6,7 @@ import androidx.annotation.Nullable;
 
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 
-import org.apache.commons.io.FileUtils;
+import org.openobservatory.ooniprobe.kt.FileUtils;
 import org.openobservatory.engine.OONIContext;
 import org.openobservatory.engine.OONISession;
 import org.openobservatory.engine.OONISubmitResults;
@@ -95,12 +95,12 @@ public class MeasurementsManager {
 
     public String getReadableLog(Measurement measurement) throws IOException {
         File logFile = Measurement.getLogFile(context, measurement.result.id, measurement.test_name);
-        return FileUtils.readFileToString(logFile, StandardCharsets.UTF_8);
+        return FileUtils.Companion.readFileToString(logFile, StandardCharsets.UTF_8);
     }
 
     public String getReadableEntry(Measurement measurement) throws IOException {
         File entryFile = Measurement.getReportFile(context, measurement.id, measurement.test_name);
-        return jsonPrinter.prettyText(FileUtils.readFileToString(entryFile, StandardCharsets.UTF_8));
+        return jsonPrinter.prettyText(FileUtils.Companion.readFileToString(entryFile, StandardCharsets.UTF_8));
     }
 
     public void downloadReport(Measurement measurement, DomainCallback<String> callback) {
@@ -124,9 +124,9 @@ public class MeasurementsManager {
         long uploadTimeout = getTimeout(file.length());
         OONIContext ooniContext = session.newContextWithTimeout(uploadTimeout);
         try {
-            input = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+            input = FileUtils.Companion.readFileToString(file, StandardCharsets.UTF_8);
             OONISubmitResults results = session.submit(ooniContext, input);
-            FileUtils.writeStringToFile(file, results.getUpdatedMeasurement(), StandardCharsets.UTF_8);
+            FileUtils.Companion.writeStringToFile(file, results.getUpdatedMeasurement(), StandardCharsets.UTF_8,/*append*/false);
             m.report_id = results.getUpdatedReportID();
             m.is_uploaded = true;
             m.is_upload_failed = false;

--- a/app/src/main/java/org/openobservatory/ooniprobe/kt/FileUtils.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/kt/FileUtils.kt
@@ -1,0 +1,18 @@
+package org.openobservatory.ooniprobe.kt
+
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.charset.Charset;
+
+class FileUtils {
+    companion object {
+        fun writeStringToFile(file: File, s: String, charsetName: Charset, append: Boolean) {
+            FileOutputStream(file, append).bufferedWriter(charsetName).use {
+                it.write(s, 0, s.length)
+            }
+        }
+        fun readFileToString(file: File, charsetName: Charset): String {
+            return file.readText(charsetName)
+        }
+    }
+}

--- a/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/test/test/AbstractTest.java
@@ -13,7 +13,7 @@ import androidx.annotation.StringRes;
 
 import com.google.gson.Gson;
 
-import org.apache.commons.io.FileUtils;
+import org.openobservatory.ooniprobe.kt.FileUtils;
 import org.openobservatory.engine.OONIMKTask;
 import org.openobservatory.ooniprobe.common.AppLogger;
 import org.openobservatory.ooniprobe.common.Application;
@@ -155,7 +155,7 @@ public abstract class AbstractTest implements Serializable {
                                 break;
                         }
                         if (logFile == null) break;
-                        FileUtils.writeStringToFile(
+                        FileUtils.Companion.writeStringToFile(
                                 logFile,
                                 event.value.message + "\n",
                                 Charset.forName("UTF-8"),
@@ -166,7 +166,7 @@ public abstract class AbstractTest implements Serializable {
                     case "status.progress":
                         testCallback.onProgress(Double.valueOf((index + event.value.percentage) * 100).intValue());
                         if (logFile == null) break;
-                        FileUtils.writeStringToFile(
+                        FileUtils.Companion.writeStringToFile(
                                 logFile,
                                 event.value.message + "\n",
                                 StandardCharsets.UTF_8,
@@ -188,10 +188,11 @@ public abstract class AbstractTest implements Serializable {
                             m.save();
                             File entryFile = Measurement.getReportFile(c, m.id, m.test_name);
                             entryFile.getParentFile().mkdirs();
-                            FileUtils.writeStringToFile(
+                            FileUtils.Companion.writeStringToFile(
                                     entryFile,
                                     event.value.json_str,
-                                    Charset.forName("UTF-8")
+                                    Charset.forName("UTF-8"),
+                                    /*append*/false
                             );
                         }
                         break;


### PR DESCRIPTION
ooni/probe#2750

## Proposed Changes

  - Implement `writeStringToFile(), readFileToString()` with some kotlin extensions in org.openobservatory.ooniprobe.kt.FileUtils
  - Replace `writeStringToFile(), readFileToString()` in `app/src/main`
