### PR TITLE
Fix: Instrumented tests on CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,15 +84,20 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          profile: pixel_3_xl
+          profile: Nexus 6
           ram-size: 4096M
-          disable-animations: true
           script: ./gradlew connectedOoniStableFullDebugAndroidTest
 
       - name: uploads test reports


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2779

## Proposed Changes
  - Enable hardware accelerated emulators (KVM) as suggested on https://github.com/ReactiveCircus/android-emulator-runner
  - Switch the emulator profile to example given on https://github.com/ReactiveCircus/android-emulator-runner
  - Remove the `disable-animations` because the default value is already `true`
