### PR TITLE
Fix flaky ResultTest and build config warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
     namespace 'org.openobservatory.ooniprobe'
 }
@@ -176,7 +177,6 @@ dependencies {
     testImplementation libs.androidx.runner
     testImplementation libs.androidx.rules
     testImplementation libs.mockito.core
-    testImplementation libs.mockito.inline
     testImplementation libs.robolectric
     testImplementation libs.faker
     testImplementation libs.ooni.oonimkall

--- a/app/src/main/java/org/openobservatory/ooniprobe/common/service/RunTestService.java
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/service/RunTestService.java
@@ -58,8 +58,9 @@ public class RunTestService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        @SuppressWarnings("unchecked")
         ArrayList<AbstractSuite> testSuites = (ArrayList<AbstractSuite>) intent.getSerializableExtra("testSuites");
-        if (testSuites == null || testSuites.size() == 0)
+        if (testSuites == null || testSuites.isEmpty())
             return START_STICKY_COMPATIBILITY;
         boolean store_db = intent.getBooleanExtra("storeDB", true);
         boolean unattended = intent.getBooleanExtra("unattended", false);

--- a/app/src/test/java/org/openobservatory/ooniprobe/model/database/ResultTest.java
+++ b/app/src/test/java/org/openobservatory/ooniprobe/model/database/ResultTest.java
@@ -43,6 +43,7 @@ public class ResultTest extends RobolectricAbstractTest {
     @Test
     public void getLastResult() {
         Result first = new Result("");
+        first.start_time = new Date(System.currentTimeMillis() - 1000);
         first.save();
         Result second = new Result("");
         second.save();

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,7 @@ androidGradlePlugin = "8.5.1"
 barista = "3.9.0"
 countlySdk = "24.7.0"
 faker = "2.0.4"
-mockitoCore = "5.12.0"
-mockitoInline = "5.2.0"
+mockito = "5.12.0"
 robolectric = "4.13"
 fastlaneScreengrab = "2.1.1"
 sentryAndroid = "7.11.0"
@@ -64,8 +63,7 @@ xanscale-localhost-toolkit = { module = "com.github.xanscale.LocalhostToolkit:ap
 commons-io = { module = "commons-io:commons-io", version.ref = "commonsIo" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 
-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
-mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
 markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon" }


### PR DESCRIPTION
I haven't created a ticket for these changes.

## Proposed Changes

  - Fix `ResultTest.getLastResult` by ensuring that the first result really has a start_time before the second result
  - Fix `BuildConfig` warning by changing to the new configuration
  - Remove the `mockito-inline` dependency, since it's no longer needed for Mockito 5

### Context

- This PR started as an attempt to fix https://github.com/ooni/probe/issues/2777 but I wasn't able to do it yet
