### PR TITLE
Cache AVD to improve instrumented tests time

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: checkout
         uses: actions/checkout@v4
@@ -50,6 +51,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: checkout
         uses: actions/checkout@v4
@@ -80,6 +82,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: checkout
         uses: actions/checkout@v4
@@ -181,6 +184,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Assemble APKs
         if: success() && steps.get_issue_number.outputs.result

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -90,6 +90,32 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}-${{ matrix.target }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          ram-size: 4096M
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -98,6 +124,9 @@ jobs:
           arch: x86_64
           profile: Nexus 6
           ram-size: 4096M
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: ./gradlew connectedOoniStableFullDebugAndroidTest
 
       - name: uploads test reports

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,10 +32,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
 
       - name: checkout
         uses: actions/checkout@v4
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build `StableFullRelease` and `StableFdroidRelease` variants
         run: ./gradlew build${{ matrix.version }} && ./gradlew clean
@@ -51,10 +53,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
 
       - name: checkout
         uses: actions/checkout@v4
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Run unit tests
         run: ./gradlew testOoniStableFullRelease
@@ -82,7 +86,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
 
       - name: checkout
         uses: actions/checkout@v4
@@ -184,7 +187,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Assemble APKs
         if: success() && steps.get_issue_number.outputs.result


### PR DESCRIPTION
## Proposed Changes

  - Apply cache suggestions from https://github.com/ReactiveCircus/android-emulator-runner to improve the instrumented tests time. It's currently taking 9-10 minutes.
  - Added more `setup-gradle` steps to further use gradle cache too. Those need to be merged to `master` to work.
