### PR TITLE
fix: change default for `ndt` and `dash` in autorun

### DIFF
--- a/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManagerExtension.kt
+++ b/app/src/main/java/org/openobservatory/ooniprobe/common/PreferenceManagerExtension.kt
@@ -31,7 +31,7 @@ fun PreferenceManager.resolveStatus(
         sp.getBoolean(
             getPreferenceKey(name = name, prefix = prefix, autoRun = true),
             when(prefix.isEmpty()) {
-                true -> true
+                true -> autorunDefault(name = name)
                 false -> false
             }
         )
@@ -183,5 +183,13 @@ private fun PreferenceManager.setValue(name: String, value: Boolean): Boolean {
     return with(sp.edit()) {
         putBoolean(getPreferenceKey(name), value)
         commit()
+    }
+}
+
+fun autorunDefault(name: String): Boolean {
+    return when (name) {
+        Ndt.NAME,
+        Dash.NAME -> false
+        else -> true
     }
 }


### PR DESCRIPTION
This assumes that the user hasn't changed the preference for running `ndt` and `dash` in autorun.